### PR TITLE
Cloaken add verify and proxy parameters to client

### DIFF
--- a/docker/cloaken/Pipfile.lock
+++ b/docker/cloaken/Pipfile.lock
@@ -32,10 +32,10 @@
         },
         "cloakensdk": {
             "hashes": [
-                "sha256:cf38becf224b54f0e8edca698b75e963bc9d456dcbb9d2dcbf6e9a6cef13ada3"
+                "sha256:c9744ceb7c10bef9fffafb3595f2592b76533bbd1866a92e6d77d58b80788a06"
             ],
             "index": "pypi",
-            "version": "==0.0.4"
+            "version": "==0.0.5"
         },
         "idna": {
             "hashes": [


### PR DESCRIPTION
We need to add the proxy parameter and the verify parameter to the http client.  This had to be added in the SDK to allow for the Cloaken integration to use it.