### PR TITLE
Cloaken add verify and proxy parameters to client

### DIFF
--- a/docker/cloaken/Pipfile.lock
+++ b/docker/cloaken/Pipfile.lock
@@ -32,10 +32,10 @@
         },
         "cloakensdk": {
             "hashes": [
-                "sha256:cf38becf224b54f0e8edca698b75e963bc9d456dcbb9d2dcbf6e9a6cef13ada3"
+                "sha256:b29ae36ecc558dc7268d3a1971859da1bd2d6216171fa813d5b255ca69df72d2"
             ],
             "index": "pypi",
-            "version": "==0.0.4"
+            "version": "==0.0.7"
         },
         "idna": {
             "hashes": [


### PR DESCRIPTION
Allow verify ssl and proxies to be used with http client.