### PR TITLE
Cloaken - added screenshots

### DIFF
--- a/docker/cloaken/Pipfile.lock
+++ b/docker/cloaken/Pipfile.lock
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
-            "version": "==2019.3.9"
+            "version": "==2019.6.16"
         },
         "chardet": {
             "hashes": [
@@ -32,10 +32,11 @@
         },
         "cloakensdk": {
             "hashes": [
-                "sha256:b29ae36ecc558dc7268d3a1971859da1bd2d6216171fa813d5b255ca69df72d2"
+                "sha256:5152937cd5a29aa6c25622feda81748aa253471bf9f897cfc3b675b437d38fa3",
+                "sha256:b3cff1cc843f663591e2d7c7bcc440def3652ad82e2154c6529d4b417e54a834"
             ],
             "index": "pypi",
-            "version": "==0.0.7"
+            "version": "==0.0.8"
         },
         "idna": {
             "hashes": [
@@ -53,9 +54,9 @@
         },
         "requests-futures": {
             "hashes": [
-                "sha256:200729e932ec1f6d6e58101a8d2b144d48c9695f0585bc1dcf37139190f699a1"
+                "sha256:35547502bf1958044716a03a2f47092a89efe8f9789ab0c4c528d9c9c30bc148"
             ],
-            "version": "==0.9.9"
+            "version": "==1.0.0"
         },
         "urllib3": {
             "hashes": [


### PR DESCRIPTION
We have updated this docker image with the latest Cloaken SDK.  This adds a new feature to retrieve screenshots.  Once this is pulled we will then be able to create a pull request for the updated integration.