### PR TITLE
dependabot config update

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -135,12 +135,6 @@ update_configs:
     directory: /docker/python3
     update_schedule: daily 
 
-  - package_manager: python
-    directory: /docker/content-build
-    update_schedule: live
-    allowed_updates:
-    - match:
-        update_type: "security"
   - package_manager: docker
     directory: /docker/content-build
     update_schedule: daily 


### PR DESCRIPTION
remove content-build from dependabot config as python deps are not used anymore

fixes: #793 