### PR TITLE
Updated google-cloud-storage

### DIFF
--- a/docker/google-cloud-storage/Dockerfile
+++ b/docker/google-cloud-storage/Dockerfile
@@ -4,5 +4,6 @@ FROM demisto/python3:3.7.5.4583
 COPY requirements.txt .
 
 RUN apk --update add --no-cache --virtual .build-dependencies python-dev build-base wget git \
+  && apk add --no-cache libstdc++ \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del .build-dependencies

--- a/docker/google-cloud-storage/Dockerfile
+++ b/docker/google-cloud-storage/Dockerfile
@@ -4,6 +4,6 @@ FROM demisto/python3:3.7.5.4583
 COPY requirements.txt .
 
 RUN apk --update add --no-cache --virtual .build-dependencies python-dev build-base wget git linux-headers \
-  && apk add --no-cache libstdc++ \
+  && apk --update add --no-cache libstdc++ \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del .build-dependencies

--- a/docker/google-cloud-storage/verify.py
+++ b/docker/google-cloud-storage/verify.py
@@ -1,0 +1,2 @@
+from google.cloud import storage
+from google.cloud import pubsub_v1


### PR DESCRIPTION
## Status
In Progress

## Related Issues
related: https://github.com/demisto/etc/issues/23146

## Description
google-cloud-storage has `google-cloud-pubsub` which is required for the integration in the related issue. The docker doesn't install it properly, as the library is dependent on libstc++, so I  added it (no virtual)