### PR TITLE
TruSTAR SDK version update

### DIFF
--- a/docker/trustar/Pipfile
+++ b/docker/trustar/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-trustar = {git = "https://github.com/trustar/trustar-python.git", editable = true, ref = "master"}
+trustar = {git = "https://github.com/trustar/trustar-python.git", editable = true, ref = "87154b98dc36c8c5a3aa9a6807be5ebdaf38ff13"}
 
 [requires]
 python_version = "3.7"

--- a/docker/trustar/Pipfile.lock
+++ b/docker/trustar/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6b5e98143e08d2edb9675fdbe5aef8b98319c4285ee62d085d54dc7e71f03a8b"
+            "sha256": "d52d56d4dd2763ee781e05e5c22dc24cdbbd2f2d35232f088d3110f9ccd747b7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -59,10 +59,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
-                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
             ],
-            "version": "==2019.3"
+            "version": "==2020.1"
         },
         "pyyaml": {
             "hashes": [
@@ -97,14 +97,14 @@
         "trustar": {
             "editable": true,
             "git": "https://github.com/trustar/trustar-python.git",
-            "ref": "d918ef494d00e496e3763806d9f391545483af2b"
+            "ref": "87154b98dc36c8c5a3aa9a6807be5ebdaf38ff13"
         },
         "tzlocal": {
             "hashes": [
-                "sha256:11c9f16e0a633b4b60e1eede97d8a46340d042e67b670b290ca526576e039048",
-                "sha256:949b9dd5ba4be17190a80c0268167d7e6c92c62b30026cf9764caf3e308e5590"
+                "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44",
+                "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"
             ],
-            "version": "==2.0.0"
+            "version": "==2.1"
         },
         "unicodecsv": {
             "hashes": [

--- a/docker/trustar/build.conf
+++ b/docker/trustar/build.conf
@@ -1,1 +1,1 @@
-version=20.0.0
+version=20.1.0


### PR DESCRIPTION
## Status
Ready

## Related Issues
An update on TruSTAR SDK requires this changes 

## Description
Some attributes have changed on our phishing triage endpoints so this requires the version bump
