### PR TITLE
py3ews - changed exchangelib to 3.2.0

### DIFF
--- a/docker/py3ews/Pipfile
+++ b/docker/py3ews/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-exchangelib = "*"
+exchangelib = "3.2.0"
 
 [requires]
 python_version = "3.8"

--- a/docker/py3ews/Pipfile
+++ b/docker/py3ews/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-exchangelib = "3.2.0"
+exchangelib = "==3.2.0"
 
 [requires]
 python_version = "3.8"


### PR DESCRIPTION
## Status
Ready

## Description
Exchangelib 3.2.0 is required for running EWS O365 integration.