### PR TITLE
install librdkafka on pykafka

### DIFF
--- a/docker/pykafka/Dockerfile
+++ b/docker/pykafka/Dockerfile
@@ -3,8 +3,9 @@ FROM demisto/python:2.7.18.8715
 
 COPY requirements.txt .
 
-RUN apk --update add --no-cache snappy  
+RUN apk --update add --no-cache snappy librdkafka
 
 RUN apk --update add --no-cache --virtual .build-dependencies python-dev build-base wget snappy-dev \
+  librdkafka-dev \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del .build-dependencies

--- a/docker/pykafka/verify.py
+++ b/docker/pykafka/verify.py
@@ -2,6 +2,7 @@ import lz4.frame as lz4
 import lz4f
 import xxhash
 import snappy
+from pykafka import rdkafka
 
 print("xxhash version: " + xxhash.XXHASH_VERSION)
 


### PR DESCRIPTION
## Status
In Progress

## Related Issues
https://panw-global.slack.com/archives/C011J0AP7J8/p1591169860126300
https://github.com/Parsely/pykafka/issues/850

## Description
adding `librdkafka` to `pykafka` docker image to handle `ImportError: cannot import name _rd_kafka`
