### PR TITLE
bump py3 base docker images to 3.8.5

### DIFF
--- a/docker/python3-deb/Dockerfile
+++ b/docker/python3-deb/Dockerfile
@@ -1,5 +1,5 @@
-# Last modified: Thu, 28 May 2020 22:53:09 +0000
-FROM python:3.8.3-slim-buster
+# Last modified: Wed, 22 Jul 2020 08:27:22 +0000
+FROM python:3.8.5-slim-buster
 
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 

--- a/docker/python3-deb/build.conf
+++ b/docker/python3-deb/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.8.3
+version=3.8.5

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,5 +1,5 @@
-# Last modified: Thu, 28 May 2020 22:53:09 +0000
-FROM python:3.8.3-alpine3.11
+# Last modified: Wed, 22 Jul 2020 08:27:22 +0000
+FROM python:3.8.5-alpine3.11
 
 # Upgrade all packages to latest
 RUN apk --update --no-cache upgrade

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -8,7 +8,7 @@ COPY requirements.txt .
 
 COPY localtime /etc/localtime
 
-RUN apk --update add --no-cache --virtual .build-dependencies python-dev build-base wget \  
+RUN apk --update add --no-cache --virtual .build-dependencies python3-dev build-base wget \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del .build-dependencies
 

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,5 +1,5 @@
 # Last modified: Wed, 22 Jul 2020 08:27:22 +0000
-FROM python:3.8.5-alpine3.11
+FROM python:3.8.5-alpine3.12
 
 # Upgrade all packages to latest
 RUN apk --update --no-cache upgrade

--- a/docker/python3/build.conf
+++ b/docker/python3/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.8.3
+version=3.8.5


### PR DESCRIPTION
## Status
Ready

## Description
bumping py3 to 3.8.5 which includes a number of security-related fixes
https://docs.python.org/release/3.8.5/whatsnew/changelog.html#python-3-8-5-final
