### PR TITLE
Handle unknown license

### DIFF
--- a/docker/verify_licenses.py
+++ b/docker/verify_licenses.py
@@ -134,12 +134,11 @@ def check_python_license(docker_image: str, licenses: dict, ignore_packages: dic
                         repo_license = req_session.get(
                             "https://api.github.com/repos/{}/license".format(owner_and_repo),
                             headers={"Accept": "application/vnd.github.v3+json"},
-                            verify=False
+                            verify=True
                         ).json()
-                        license_name = repo_license.get('license', {}).get('name')
-                        if license_name:
-                            print("{}: found license from GitHub API: {}".format(name, license_name))
-                            found_licenses.append(license_name)
+                        license_name = repo_license.get('license', {}).get('name', 'NOT_FOUND_IN_GITHUB')
+                        print("{}: found license from GitHub API: {}".format(name, license_name))
+                        found_licenses.append(license_name)
                     else:
                         print("{}: found license from pip show: {}".format(name, line))
                         found_licenses.append(line)

--- a/docker/verify_licenses.py
+++ b/docker/verify_licenses.py
@@ -137,8 +137,9 @@ def check_python_license(docker_image: str, licenses: dict, ignore_packages: dic
                             verify=False
                         ).json()
                         license_name = repo_license.get('license', {}).get('name')
-                        print("{}: found license from GitHub API: {}".format(name, license_name))
-                        found_licenses.append(license_name)
+                        if license_name:
+                            print("{}: found license from GitHub API: {}".format(name, license_name))
+                            found_licenses.append(license_name)
                     else:
                         print("{}: found license from pip show: {}".format(name, line))
                         found_licenses.append(line)


### PR DESCRIPTION

## Status
Ready


## Description
as seen in https://app.circleci.com/pipelines/github/demisto/dockerfiles/4844/workflows/e7671d1c-d02f-416e-955d-c54bdeb61d07/jobs/10720/parallel-runs/0/steps/0-106, `pip show` returned `UNKNOWN` license

added handling of that case by querying the package github repo to get the license from there

related PR: https://github.com/demisto/dockerfiles/pull/2404
