### PR TITLE
creating a docker image for sccm

### DIFF
--- a/docker/pwsh-remoting/Dockerfile
+++ b/docker/pwsh-remoting/Dockerfile
@@ -1,3 +1,9 @@
-FROM demisto/powershell-ubuntu:6.2.4.6258
+FROM demisto/powershell-ubuntu:7.0.1.9103
+
+RUN mkdir /root/.ssh
+#Supressing the interactive host verification prompt
+RUN echo "StrictHostKeyChecking no" >> /root/.ssh/config
+#Supressing the 'Permanently added '<ssh-host-name>' (ECDSA) to the list of known hosts' warning.
+RUN echo "LogLevel ERROR" >> /root/.ssh/config
 
 RUN apt-get update && apt-get install -y --no-install-recommends openssh-client


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
In Progress

## Related Issues
related: https://github.com/demisto/etc/issues/10273

## Description
Added a docker image that will make sshing into a windows machine non-interactive and supressed warning messages about `Permanently added '<ssh-host-name>' (ECDSA) to the list of known hosts`