### PR TITLE
bump py3 docker images to 3.9

### DIFF
--- a/docker/python3-deb/Dockerfile
+++ b/docker/python3-deb/Dockerfile
@@ -1,5 +1,5 @@
-# Last modified: Wed, 22 Jul 2020 08:27:22 +0000
-FROM python:3.8.6-slim-buster
+# Last modified: Wed, 07 Oct 2020 04:37:17 +0000
+FROM python:3.9.0-slim-buster
 
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 

--- a/docker/python3-deb/build.conf
+++ b/docker/python3-deb/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.8.5
+version=3.9.0

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,5 +1,5 @@
-# Last modified: Wed, 22 Jul 2020 08:27:22 +0000
-FROM python:3.8.6-alpine3.12
+# Last modified: Wed, 07 Oct 2020 04:37:17 +0000
+FROM python:3.9.0-alpine3.12
 
 # Upgrade all packages to latest
 RUN apk --update --no-cache upgrade

--- a/docker/python3/build.conf
+++ b/docker/python3/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.8.5
+version=3.9.0


### PR DESCRIPTION

## Status
Ready

## Description
bumped py3 base images to 3.9
