### PR TITLE
PWSH - Add remote repo

### DIFF
--- a/docker/powershell-ubuntu/Dockerfile
+++ b/docker/powershell-ubuntu/Dockerfile
@@ -8,3 +8,5 @@ RUN apt-get update && apt-get -y --no-install-recommends upgrade \
 
 RUN groupadd --gid 4000 demisto \
   && useradd --uid 4000 --gid demisto --shell /bin/bash --create-home demisto
+
+RUN pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted"


### PR DESCRIPTION
## Status
Ready

## Description
Adding PSGallery as a remote repo.
In default (Not-ubuntu based), it comes by default as it's the official repo for modules. 