### PR TITLE
Ansible-runner requires openssh-client/sshpass pkgs

### DIFF
--- a/docker/ansible-runner/Dockerfile
+++ b/docker/ansible-runner/Dockerfile
@@ -16,6 +16,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-dev \
   linux-libc-dev \
   libc6-dev \
-  sshpass \
-  openssh-client \
 && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Status
Ready

## Related Issues
* https://github.com/demisto/content/pull/9197

## Description
Not sure why I was removing the sshpass & openssh-client packages after installing them in the container, they are are required for advanced ssh key authentication in Ansible. Just noticed this while testing the Ansible content pack linked in the related issues.
