### PR TITLE
py2-exchangelib: support tls1.0

### DIFF
--- a/docker/py2-exchangelib/Dockerfile
+++ b/docker/py2-exchangelib/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM demisto/python-deb:2.7.18.15627
+FROM demisto/python-deb:2.7.18.14969
 
 COPY requirements.txt .
 
@@ -11,3 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   python2-dev \
 && rm -rf /var/lib/apt/lists/*
+
+# update openssl.cnf to support TLS 1.0 (old exchange servers)
+RUN sed -i s/DEFAULT@SECLEVEL=2/DEFAULT@SECLEVEL=1/g /etc/ssl/openssl.cnf \
+  && sed -i s/TLSv1.2/TLSv1/g /etc/ssl/openssl.cnf


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
related: https://github.com/demisto/etc/issues/33096

## Description
Support for older exchange servers which still use tls1.0
