### PR TITLE
Update cyjax-cti python SDK to 1.0.6

### DIFF
--- a/docker/cyjax/Pipfile.lock
+++ b/docker/cyjax/Pipfile.lock
@@ -33,11 +33,11 @@
         },
         "cyjax-cti": {
             "hashes": [
-                "sha256:2ccb7aa786749fe00f5aeaf899409a45f31a7d0dc2df85f6839a7a496c2b6854",
-                "sha256:f7e82cb6c0c3919ea70fc5cf65d145374741b003e8e3726bdc1e678d44067538"
+                "sha256:04859331b4721a0c8da17cae12182d7c76b7c5c37ef3c08ffa57d98e3d9985e7",
+                "sha256:4097d21130607e8c3b5c464164d99c94d67b07122dcc6864f42adde4c05772c3"
             ],
             "index": "pypi",
-            "version": "==1.0.5"
+            "version": "==1.0.6"
         },
         "idna": {
             "hashes": [
@@ -80,11 +80,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
+                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.2"
+            "version": "==1.26.3"
         }
     },
     "develop": {}


### PR DESCRIPTION

## Status
Ready

## Description
Bump cyjax-cti python SDK to 1.0.6
