### PR TITLE
fix pipfile for unifi-video

### DIFF
--- a/docker/unifi-video/Pipfile.lock
+++ b/docker/unifi-video/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7e7ef69da7248742e869378f8421880cf8f0017f96d94d086813baa518a65489"
+            "sha256": "59c15b7f220efcdd99d318b7c6a632bd4159a770895c50628274bb5912f5ac1b"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -15,6 +15,14 @@
             }
         ]
     },
-    "default": {},
+    "default": {
+        "unifi-video": {
+            "hashes": [
+                "sha256:cdcfb3cb00942c12fb91a1cef77f8b21223f71a4f94d7f2710fddd0d1a97e255"
+            ],
+            "index": "pypi",
+            "version": "==0.3.1"
+        }
+    },
     "develop": {}
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
related: https://github.com/demisto/dockerfiles/pull/4157

## Description
Fix. pipfile.lock. @barchen1 it seems that you didn't run: `pipenv install` in the directory: `docker/unifi-video`. This is needed if you don't use the `./docker/create_new_docker_image.py` script.
