### PR TITLE
fixed pymisp version

### DIFF
--- a/docker/pymisp/Pipfile
+++ b/docker/pymisp/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-pymisp = "==v2.4.111"
+pymisp = "==v2.4.99"
 pybase64 = "*"
 
 [requires]

--- a/docker/pymisp/Pipfile.lock
+++ b/docker/pymisp/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aa7c2272c92cf3d791a04263d9f947a22f21a8e9e126f80343979703fd3d029b"
+            "sha256": "1f2091af95cc4bca7f22615149518bf7dfea59ee006cfe8f572f445292c6e8bd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -127,12 +127,12 @@
         },
         "pymisp": {
             "hashes": [
-                "sha256:e7ae9f703ea572caec3557c3aa27dcdc7212cbc0390445ff3dc3e332bb749026",
-                "sha256:f19fd1a0f3bf207a074593be19cd6cb730e608b236717ac261bc9a26c7138075",
-                "sha256:f728643cdbfff2000c058648ba82a595525eda64019bd71649b5b50ca1921cd2"
+                "sha256:3f7c72856813e3b1dce4d9e7efb4d2c636f092bb25de1a90e7e24f176b9d33e5",
+                "sha256:400ad591dcce2f6fd4b2d8795001bef1735a753baebfe6e32a698fc47d0a4d25",
+                "sha256:68756cd285deed443a6f4eae2dc2d236c46ebc33376c280a87a8563fcfaa6682"
             ],
             "index": "pypi",
-            "version": "==2.4.111"
+            "version": "==2.4.99"
         },
         "pyrsistent": {
             "hashes": [


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related PR
related: https://github.com/demisto/dockerfiles/pull/4970

## Description
using a different fixed version (the one used in the current docker image of the integration) as the new version is still causing problems.
