### PR TITLE
python3: bump to 3.9.5 + set tldextract on 2.2.x

### DIFF
--- a/docker/python3-deb/Dockerfile
+++ b/docker/python3-deb/Dockerfile
@@ -1,5 +1,5 @@
 # Last modified: Fri, 26 Mar 2021 16:21:13 +0000
-FROM python:3.9.4-slim-buster
+FROM python:3.9.5-slim-buster
 
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 

--- a/docker/python3-deb/Pipfile
+++ b/docker/python3-deb/Pipfile
@@ -12,7 +12,7 @@ python-dateutil = "*"
 dateparser = "*"
 pyyaml = "*"
 funcy = "*"
-tldextract = "*"
+tldextract = "~=2.2"
 
 [requires]
-python_version = "3.8"
+python_version = "3.9"

--- a/docker/python3-deb/Pipfile.lock
+++ b/docker/python3-deb/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3fb44d6d8f5a577831040e52e8de73ce20af51bc57a851c92c9e3c32873c731b"
+            "sha256": "759bbd56e63ba52923b8c4e81efbf28f0b6b8b31c5da01a08197378d2fc0a10d"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -28,6 +28,7 @@
                 "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
                 "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
         "dateparser": {
@@ -51,6 +52,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "olefile": {
@@ -187,6 +189,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tldextract": {
@@ -209,6 +212,7 @@
                 "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
                 "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.4"
         }
     },

--- a/docker/python3-deb/build.conf
+++ b/docker/python3-deb/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.9.4
+version=3.9.5

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,5 +1,5 @@
 # Last modified: Fri, 26 Mar 2021 16:21:13 +0000
-FROM python:3.9.4-alpine3.13
+FROM python:3.9.5-alpine3.13
 
 # Upgrade all packages to latest
 RUN apk --update --no-cache upgrade

--- a/docker/python3/Pipfile
+++ b/docker/python3/Pipfile
@@ -12,7 +12,7 @@ python-dateutil = "*"
 dateparser = "*"
 pyyaml = "*"
 funcy = "*"
-tldextract = "*"
+tldextract = "~=2.2"
 
 [requires]
-python_version = "3.8"
+python_version = "3.9"

--- a/docker/python3/Pipfile.lock
+++ b/docker/python3/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3fb44d6d8f5a577831040e52e8de73ce20af51bc57a851c92c9e3c32873c731b"
+            "sha256": "759bbd56e63ba52923b8c4e81efbf28f0b6b8b31c5da01a08197378d2fc0a10d"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -28,6 +28,7 @@
                 "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
                 "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
         "dateparser": {
@@ -51,6 +52,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "olefile": {
@@ -187,6 +189,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tldextract": {
@@ -209,6 +212,7 @@
                 "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
                 "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.4"
         }
     },

--- a/docker/python3/build.conf
+++ b/docker/python3/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.9.4
+version=3.9.5


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
related: link to the issue

## Description
Related issue to track upgrade of tldextract: https://github.com/demisto/etc/issues/37003