### PR TITLE
Update build_docker.sh for local execution

### DIFF
--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -155,15 +155,15 @@ function docker_build {
         cat requirements.txt
         del_requirements=yes
     fi
-    tmp_dockerfile=$(mktemp)
-    cp Dockerfile "$tmp_dockerfile"
-    echo "" >> "$tmp_dockerfile"
-    echo "ENV DOCKER_IMAGE=$image_full_name" >> "$tmp_dockerfile"
-    docker build -f "$tmp_dockerfile" . -t ${image_full_name} \
+    tmp_dir=$(mktemp -d)
+    cp Dockerfile "$tmp_dir/Dockerfile"
+    echo "" >> "$tmp_dir/Dockerfile"
+    echo "ENV DOCKER_IMAGE=$image_full_name" >> "$tmp_dir/Dockerfile"
+    docker build -f "$tmp_dir/Dockerfile" . -t ${image_full_name} \
         --label "org.opencontainers.image.authors=Demisto <containers@demisto.com>" \
         --label "org.opencontainers.image.version=${VERSION}" \
         --label "org.opencontainers.image.revision=${CIRCLE_SHA1}"
-    rm "$tmp_dockerfile"
+    rm -rf "$tmp_dir"
     if [ ${del_requirements} = "yes" ]; then
         rm requirements.txt
     fi

--- a/docker/sane-pdf-reports/Dockerfile
+++ b/docker/sane-pdf-reports/Dockerfile
@@ -1,4 +1,4 @@
-# Last modified: Mon, 23 May 2021 09:48:37 +0200
+# Last modified: Mon, 25 May 2021 09:48:37 +0200
 FROM demisto/python3-deb:3.9.5.20070
 
 WORKDIR "/app"


### PR DESCRIPTION
## Status
Ready

## Description
When running `./docker/build_docker.sh <image>` to build an image locally for testing, I was getting errors similar to the screenshot attached below
> Partial output from executing `./doocker/build_docker.sh ldap`
![image](https://user-images.githubusercontent.com/46294017/119544291-3bc03e80-bd9a-11eb-8e42-3f04c058a071.png)

The changes I made to the `build_docker.sh` script made it so that it worked locally again as expected.
