### PR TITLE
Fix for Powershell host trust issue

### DIFF
--- a/docker/pwsh-azure/Dockerfile
+++ b/docker/pwsh-azure/Dockerfile
@@ -2,5 +2,5 @@
 FROM demisto/powershell:7.1.3.20923
 
 RUN pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction Stop"
-RUN pwsh -c "Install-Module -ErrorAction Stop Az -Scope AllUsers""
+RUN pwsh -c "Install-Module -ErrorAction Stop Az -Scope AllUsers"
 

--- a/docker/pwsh-azure/Dockerfile
+++ b/docker/pwsh-azure/Dockerfile
@@ -2,5 +2,5 @@
 FROM demisto/powershell:7.1.3.20923
 
 RUN pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction Stop"
-RUN pwsh -c "Install-Module -ErrorAction Stop Az"
+RUN pwsh -c "Install-Module -ErrorAction Stop Az -Scope AllUsers""
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
In Progress

## Related Issues
Related: https://github.com/demisto/etc/issues/38964

## Description
The module installation was missing `-Scope AllUsers` which would prevent it from being installed with the proper permissions required for host users. I added this and the test in the issue mentioned is resolved.
