### PR TITLE
bump up chromium docker image to mitigate latest several CVE in Chrome

### DIFF
--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -1,4 +1,4 @@
-# Last modified: Sat, 18 Sep 2021 16:44:10 +0000
+# Last modified: Mon, 04 Oct 2021 06:43:54 +0000
 FROM demisto/python3-deb:3.9.7.24076
 
 COPY requirements.txt .

--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Will install the latest version available from the chrome repo.
 # To see available chromedriver go to https://chromedriver.storage.googleapis.com/ and search for the major version
 # of chrome(for  example 91.0).
-# upgrade to the latest release.
 
 COPY download_chromedriver.sh .
 

--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Will install the latest version available from the chrome repo.
 # To see available chromedriver go to https://chromedriver.storage.googleapis.com/ and search for the major version
 # of chrome(for  example 91.0).
+# upgrade to the latest release.
 
 COPY download_chromedriver.sh .
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
In Progress

## Related Issues
Related: https://github.com/demisto/etc/issues/41764

## Description
All the CVE are mentioned in here https://chromereleases.googleblog.com/2021/09/stable-channel-update-for-desktop_30.html

High CVE-2021-37974 : published on 2021-09-01
High CVE-2021-37975 : published on 2021-09-24
Medium CVE-2021-37976 : published on on 2021-09-21
