### PR TITLE
update chromium docker to have the latest chrome version

### DIFF
--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -1,4 +1,4 @@
-# Last modified: Mon, 04 Oct 2021 06:43:54 +0000
+# Last modified: Sat, 30 Oct 2021 15:07:45 +0000
 FROM demisto/python3-deb:3.9.7.24076
 
 COPY requirements.txt .


### PR DESCRIPTION
update chromium docker to have the latest chrome version with the latest security fixes.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
In Progress

## Related Content Pull Request
Related PR: link 

## Related Issues
Related: [issue:42713](https://github.com/demisto/etc/issues/42713)

## Description
update the chromium docker image to have the latest chrome version with latest included fixes:
https://chromereleases.googleblog.com/2021/10/stable-channel-update-for-desktop_28.html
