### PR TITLE
bumping up base image python3 to use python 3.9.8 and upgrade alpine to 3.14.3

### DIFF
--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,5 +1,5 @@
 # Last modified: Wed, 01 Sep 2021 10:56:04 +0000
-FROM python:3.9.7-alpine3.14
+FROM python:3.9.8-alpine3.14
 
 # Upgrade all packages to latest
 RUN apk --update --no-cache upgrade

--- a/docker/python3/build.conf
+++ b/docker/python3/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.9.7
+version=3.9.8


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
In Progress


## Related Issues
Related: (43703)[https://github.com/demisto/etc/issues/43703]

## Description
bumping up base image python3 to use python 3.9.8 and upgrade alpine to 3.14.3
