### PR TITLE
bumping up base image py3 (deb) to python 3.9.8 and debian 11.1 bullseyes

### DIFF
--- a/docker/python3-deb/Dockerfile
+++ b/docker/python3-deb/Dockerfile
@@ -1,7 +1,7 @@
 # Last modified: Wed, 01 Sep 2021 10:56:04 +0000
-FROM python:3.9.7-slim-buster
+FROM python:3.9.8-slim-bullseye
 
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list
 
 # Basic linux utilities
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get -y --no-install-recommends upgrade \
 && rm -rf /var/lib/apt/lists/*
 
 # Upgrade using backports
-RUN apt-get update && apt-get -t buster-backports -y --no-install-recommends upgrade \
+RUN apt-get update && apt-get -t bullseye-backports -y --no-install-recommends upgrade \
 && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/docker/python3-deb/build.conf
+++ b/docker/python3-deb/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.9.7
+version=3.9.8


### PR DESCRIPTION

## Status
Ready

## Related Issues
Related: [43706](https://github.com/demisto/etc/issues/43706)

## Description
bumping up base image python3 (debian) to use python 3.9.8 and bumping up the debian to 11.1 bullseyes