### PR TITLE
bumping up base image python2 to alpine 3.14.3

### DIFF
--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: THIS DOCKERFILE IS BASED UPON: https://raw.githubusercontent.com/docker-library/python/f1e613f48eb4fc88748b36787f5ed74c14914636/2.7/alpine3.11/Dockerfile
 # We only change to use the latest Alpine version. 
 
-# Last modified: Wed, 01 Sep 2021 17:54:01 +0000
+# Last modified: Sun, 14 Nov 2021 17:27:37 +0000
 FROM alpine:3.14
 
 # ensure local python is preferred over distribution python


### PR DESCRIPTION

## Status
Ready

## Related Issues
Related: [43704](https://github.com/demisto/etc/issues/43704)

## Description
bumping up base image python2 to alpine 3.14.3