### PR TITLE
add expel python image

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,6 +6,13 @@ version: 1
 update_configs:
 
   - package_manager: python
+    directory: /docker/expel
+    update_schedule: live
+    automerged_updates:
+    - match:
+        update_type: semver:minor
+
+  - package_manager: python
     directory: /docker/pcap-http-extractor
     update_schedule: live
     automerged_updates:

--- a/docker/expel/Dockerfile
+++ b/docker/expel/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3
+
+RUN pip3 install pyexclient


### PR DESCRIPTION
## Status
Ready

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: link to the issue

## Description
This docker image will allow development in XSOAR using the expel python client https://github.com/expel-io/pyexclient/

