### PR TITLE
bumping up base image python2 on debian to use latest debian bullseye

### DIFF
--- a/docker/python-deb/Dockerfile
+++ b/docker/python-deb/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: THIS DOCKERFILE IS BASED ON: https://raw.githubusercontent.com/docker-library/python/f1e613f48eb4fc88748b36787f5ed74c14914636/2.7/buster/slim/Dockerfile
 # We only change to use the latest debian version. 
 
-# Last modified: Wed, 01 Sep 2021 17:54:01 +0000
+# Last modified: Tue, 28 Dec 2021 18:14:25 +0000
 FROM debian:bullseye-slim
 
 # ensure local python is preferred over distribution python


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/

## Description
bumping up base image python2 on debian to use latest debian bullseye