### PR TITLE
bumping python images to be base on alpine:3.15.2

### DIFF
--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -3,7 +3,7 @@
 # We only change to use the latest Alpine version. 
 
 # Last modified: Sun, 14 Nov 2021 17:27:37 +0000
-FROM alpine:3.15
+FROM alpine:3.15.2
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
Related:  https://github.com/demisto/etc/issues/47584

## Description
upgrading python docker to be based on alpine-3.15.2
