### PR TITLE
Py3 bumping up to 3 10 4 including patch for oepnssl CVE-2022-0778

### DIFF
--- a/docker/python-deb/Dockerfile
+++ b/docker/python-deb/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: THIS DOCKERFILE IS BASED ON: https://raw.githubusercontent.com/docker-library/python/f1e613f48eb4fc88748b36787f5ed74c14914636/2.7/buster/slim/Dockerfile
 # We only change to use the latest debian version. 
 
-# Last modified: Tue, 28 Dec 2021 18:14:25 +0000
+# Last modified: Sun, 27 Mar 2022 11:26:13 +0000
 FROM debian:bullseye-slim
 
 # ensure local python is preferred over distribution python

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -3,7 +3,7 @@
 # We only change to use the latest Alpine version. 
 
 # Last modified: Sun, 14 Nov 2021 17:27:37 +0000
-FROM alpine:3.15
+FROM alpine:3.15.2
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH

--- a/docker/python3-deb/Dockerfile
+++ b/docker/python3-deb/Dockerfile
@@ -1,5 +1,5 @@
 # Last modified: Sun, 23 Jan 2022 10:42:29 +0000
-FROM python:3.10.1-slim-bullseye
+FROM python:3.10.4-slim-bullseye
 
 RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list
 
@@ -21,11 +21,11 @@ COPY requirements.txt .
 #Install tools for building binary deps (will be reomved later on)
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
-  python-dev \ 
+  python3-dev \ 
 && pip install --no-cache-dir -r requirements.txt \
 && apt-get purge -y --auto-remove \
   gcc \
-  python-dev \
+  python3-dev \
 && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid 4000 demisto \

--- a/docker/python3-deb/build.conf
+++ b/docker/python3-deb/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.10.1
+version=3.10.4

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,5 +1,5 @@
 # Last modified: Thu, 06 Jan 2022 11:44:29 +0000
-FROM python:3.10.1-alpine3.15
+FROM python:3.10.4-alpine3.15
 
 # Upgrade all packages to latest
 RUN apk --update --no-cache upgrade

--- a/docker/python3/build.conf
+++ b/docker/python3/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.10.1
+version=3.10.4


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
Related: https://github.com/demisto/etc/issues/47584

## Description
bumping up the python3 version to 3.10.4
