### PR TITLE
updating chrome version to 99.0.4844.84 (CVE-2022-1096)

### DIFF
--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -1,5 +1,5 @@
-# Last modified: Sun, 20 Feb 2022 10:16:15 +0000
-FROM demisto/python3-deb:3.10.1.26244
+# Last modified: Tue, 29 Mar 2022 08:37:16 +0000
+FROM demisto/python3-deb:3.10.4.27798
 
 COPY requirements.txt .
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
Related: [47611](https://github.com/demisto/etc/issues/47611)

## Description
updating chrome version to 99.0.4844.84 (CVE-2022-1096)
