### PR TITLE
updating chrome to 100.0.4.896.60 to cover latest release from march 29, 2022

### DIFF
--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -1,4 +1,4 @@
-# Last modified: Tue, 29 Mar 2022 08:37:16 +0000
+# Last modified: Wed, 30 Mar 2022 09:21:19 +0000
 FROM demisto/python3-deb:3.10.4.27798
 
 COPY requirements.txt .


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready


## Related Issues
Related: [47611](https://github.com/demisto/etc/issues/47611)

## Description
updating chrome to 100.0.4.896.60 to cover latest release from march 29, 2022
https://chromereleases.googleblog.com/2022/03/stable-channel-update-for-desktop_29.html