### PR TITLE
bumping up the crypto docker to be based on the latest python3

### DIFF
--- a/docker/crypto/Dockerfile
+++ b/docker/crypto/Dockerfile
@@ -1,7 +1,7 @@
 
 # Note: use this image as a base if you are dependent upon cryptography
 # See teams image for an example.
-FROM demisto/python3:3.9.7.24076
+FROM demisto/python3:3.10.4.28442
 
 COPY requirements.txt .
 

--- a/docker/crypto/Pipfile
+++ b/docker/crypto/Pipfile
@@ -11,4 +11,4 @@ cffi = "*"
 msal = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.10"

--- a/docker/crypto/Pipfile.lock
+++ b/docker/crypto/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8a000566b42b700e3e64237b78d079c573e6e271bf28550b632976c49d5fc3d7"
+            "sha256": "fc892542cc44a65cfc031b710c51043c8f8a18eea6858372de6eef576b06d0c3"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.10"
         },
         "sources": [
             {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Content Pull Request
Related PR: [47981](https://github.com/demisto/etc/issues/47981)

## Related Issues
Related: link to the issue

## Description
bumping up the crypto docker to be based on the latest python3