### PR TITLE
Add support for the deprected and internal images list

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The build script will check for a `build.conf` file in the target image director
 * **version**: The version to use for tagging. Default: `1.0.0`. Note: that additionally, the CircleCI build number is always appended to the version as a revision (for example: `1.0.0.15519`) to create a unique version per build.
 * **devonly**: If set the image will be pushed only to the `devdemisto` org in docker hub and will not be pushed to the `demisto` org. Should be used for images which are for development purposes only (such as the image used in CircleCI to build this project).
 * **deprecated**: If set the image will be listed as deprecated in the deprecated_images.json file and the image will be forbidden form using in the integrations/automations.
-* **deprecated-reason**: Free text that explain the deprecation reason.
+* **deprecated_reason**: Free text that explain the deprecation reason.
 
 ## Base Python Images
 There are 4 base python images which should be used when building a new image which is based upon python:
@@ -212,10 +212,10 @@ For example:
 
 To mark an image as deprecated please follow the following steps:
 
-* 1- Add the following tow keys to the build.conf of the image.
+1. Add the following two keys to the build.conf of the image.
 
   * deprecated=true
-  * deprecated_reason="free text"
+  * deprecated_reason=free text
 
   (i.e.:
   version=1.0.0
@@ -225,6 +225,6 @@ To mark an image as deprecated please follow the following steps:
 * 2- Build the docker by running the docker/build_docker.sh
   * (i.e. /home/users/dockerfiles$ docker/build_docker.sh emoji)
   By running the build script the image information will be added to the deprecated_images.json and 2 new environment variables will be introduced in the docker :
-  * DEPRECATED=true
+  * DEPRECATED_IMAGE=true
   * DEPRECATED_REASON="the same text as deprecated_reason key from the build.conf file"
 * 3- commit all chnaged files including the deprecated_image.json and create a new PR

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ The build script will check for a `build.conf` file in the target image director
 
 * **version**: The version to use for tagging. Default: `1.0.0`. Note: that additionally, the CircleCI build number is always appended to the version as a revision (for example: `1.0.0.15519`) to create a unique version per build.
 * **devonly**: If set the image will be pushed only to the `devdemisto` org in docker hub and will not be pushed to the `demisto` org. Should be used for images which are for development purposes only (such as the image used in CircleCI to build this project).
+* **deprecated**: If set the image will be listed as deprecated in the deprecated_images.json file and the image will be forbidden form using in the integrations/automations.
+* **deprecated-reason**: Free text that explain the deprecation reason.
 
 ## Base Python Images
 There are 4 base python images which should be used when building a new image which is based upon python:
@@ -205,3 +207,24 @@ For example:
 ```
 ./docker/add_dependabot.sh docker/nmap
 ```
+
+### How to mark image as deprecated
+
+To mark an image as deprecated please follow the following steps:
+
+* 1- Add the following tow keys to the build.conf of the image.
+
+  * deprecated=true
+  * deprecated_reason="free text"
+
+  (i.e.:
+  version=1.0.0
+  deprecated=true
+  deprecated_reason="the image was merged into py3-tools")
+
+* 2- Build the docker by running the docker/build_docker.sh
+  * (i.e. /home/users/dockerfiles$ docker/build_docker.sh emoji)
+  By running the build script the image information will be added to the deprecated_images.json and 2 new environment variables will be introduced in the docker :
+  * DEPRECATED=true
+  * DEPRECATED_REASON="the same text as deprecated_reason key from the build.conf file"
+* 3- commit all chnaged files including the deprecated_image.json and create a new PR

--- a/docker/add_image_to_deprecated_or_internal_list.py
+++ b/docker/add_image_to_deprecated_or_internal_list.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+import os
+import argparse
+from datetime import datetime, timezone
+from enum import unique, Enum
+import json
+from json import JSONDecodeError
+
+@unique
+class error(Enum):
+    entry_was_added = 0    
+    entry_exists = 1
+    reason_empty = 2
+    file_not_exists = 3
+    error_reading_file = 4
+    bad_json_file = 5
+    general_error = 6
+
+
+def add_image_to_deprecated_list(image_name :str, reason :str, file_path :str, verbose=False):
+    """ adding gioving docker image to the deprecation list. make sure no duplictation etc....
+
+    Args:
+        image_name: The docker image name.
+        reason: a free text to be add to the entry as the reason for the deprecation/intelnal user.
+        file_path: A file path to the deprecated list (i.e.: deprecated.json)
+        verbose: to print out extra information help to investigate
+    Returns:
+        error
+    """
+    file_is_empty = os.path.exists(file_path) and os.stat(file_path).st_size == 0
+    with open(file_path, 'r+') as fp:
+        try:
+            if not file_is_empty:
+                image_list = json.loads(fp.read())
+            else:
+                image_list = []
+
+            if(any (image_name in image["image_name"] for image in image_list)):
+                fp.close()
+                if verbose:
+                    image = [image for image in image_list if image_name in image['image_name']]
+                    print(image)
+                print(f"{image_name} already exists in the list {file_path}")
+                fp.close()
+                return error.entry_exists
+            
+            fp.seek(0)
+            addition_time_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            image_list.append(dict({ 
+                "image_name" : f"{image_name}", 
+                "reason" : f"{reason}", 
+                "created_time_utc" : f"{addition_time_str}" 
+            }))
+            image_list_string = json.dumps(image_list)
+            if verbose:
+                print(image_list_string)
+            fp.write(image_list_string)
+            fp.close()
+            print(f"{image_name}: was added to the list {file_path}")
+            return error.entry_was_added
+        
+        except FileExistsError as exp:
+            print(f"{file_path}: is not exists make sure you are running from the the root folder of the dockerfiles repo (i.e.: /home/developer_name/dev/dockerfiles" \
+                "or make sure you are running the tools wiht fule file path to the file.")
+            if verbose:
+                print(f"Exception: {exp}")
+            return error.file_not_exists
+        except OSError as exp:
+            print(f"{file_path}: permission error ")
+            if verbose:
+                print(f"Exception: {exp}")
+            if fp:
+                fp.clsoe()
+            return error.error_reading_file
+        except JSONDecodeError or TypeError as exp:
+            print (f"{file_path}: has bad format or decoding issue")
+            if verbose:
+                print (f"Exception: {exp}")
+            if fp:
+                fp.close()
+            return error.bad_json_file
+        except Exception as exp:
+            print(f"unexpected error occured exception ")
+            if verbose:
+                print(f"Exception: {exp}")
+            if fp:
+                fp.close()
+            return error.general_error
+
+
+def handle_args():
+    parser = argparse.ArgumentParser(description='add giving image to the deprecated/internal image list')
+    parser.add_argument("name", help="The image name to get the tag for. For example: demisto/python3")
+    parser.add_argument("reason", help="A free text argument to be added to the entry as the reason for addition")
+    parser.add_argument("file_path", help="file path to the deprectaed file list")
+    parser.add_argument("--verbose", help="Specify if to print verbose data while adding the new entry to list",
+                        choices=['true', 'false'], default='false')
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = handle_args()
+    image_name = args.name
+    reason = args.reason
+    file_path = args.file_path
+    verbose = args.verbose == 'true'
+    if not reason or len(reason) <= 0:
+        print ("reason field for the entry is empty")
+        return error.reason_empty
+    return_value = add_image_to_deprecated_list(image_name, reason, file_path, verbose)
+    return return_value
+
+if __name__ == "__main__":
+    main()

--- a/docker/add_image_to_deprecated_or_internal_list.py
+++ b/docker/add_image_to_deprecated_or_internal_list.py
@@ -19,7 +19,7 @@ class error(Enum):
 
 
 def add_image_to_deprecated_list(image_name :str, reason :str, file_path :str, verbose=False):
-    """ adding gioving docker image to the deprecation list. make sure no duplictation etc....
+    """ adding giving docker image to the deprecation list. make sure no duplictation etc....
 
     Args:
         image_name: The docker image name.
@@ -67,7 +67,7 @@ def add_image_to_deprecated_list(image_name :str, reason :str, file_path :str, v
         
         except FileExistsError as exp:
             print(f"{file_path}: is not exists make sure you are running from the the root folder of the dockerfiles repo (i.e.: /home/developer_name/dev/dockerfiles" \
-                "or make sure you are running the tools wiht fule file path to the file.")
+                "or make sure you are running the tools wiht full file path to the file.")
             if verbose:
                 print(f"Exception: {exp}")
             return error.file_not_exists

--- a/docker/add_image_to_deprecated_or_internal_list.py
+++ b/docker/add_image_to_deprecated_or_internal_list.py
@@ -43,11 +43,7 @@ def add_image_to_deprecated_list(image_name :str, reason :str, file_path :str, v
 
             if(any (image_name in image["image_name"] for image in image_list)):
                 fp.close()
-                if verbose:
-                    image = [image for image in image_list if image_name in image['image_name']]
-                    print(image)
-                print(f"{image_name} already exists in the list {file_path}")
-                fp.close()
+                print(f"{image_name} already exists in the list {file_path}")                
                 return error.entry_exists
             
             fp.seek(0)

--- a/docker/add_image_to_deprecated_or_internal_list.py
+++ b/docker/add_image_to_deprecated_or_internal_list.py
@@ -1,21 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
+import sys
 import argparse
 from datetime import datetime, timezone
-from enum import unique, Enum
+from enum import IntEnum
 import json
 from json import JSONDecodeError
 
-@unique
-class error(Enum):
-    entry_was_added = 0    
-    entry_exists = 1
-    reason_empty = 2
-    file_not_exists = 3
-    error_reading_file = 4
-    bad_json_file = 5
-    general_error = 6
+
+class error(IntEnum):
+    entry_was_added = 0 
+    entry_exists = 0
+    empty_reason = 1
+    file_not_exists = 2
+    error_reading_file = 3
+    bad_json_file = 4
+    general_error = 5
 
 
 def add_image_to_deprecated_list(image_name :str, reason :str, file_path :str, verbose=False):
@@ -39,7 +40,7 @@ def add_image_to_deprecated_list(image_name :str, reason :str, file_path :str, v
 
             if not reason or len(reason) <= 0:
                 print ("reason field for the entry is empty")
-                return error.reason_empty
+                return error.empty_reason
 
             if(any (image_name in image["image_name"] for image in image_list)):
                 fp.close()
@@ -107,7 +108,8 @@ def main():
     file_path = args.file_path
     verbose = args.verbose == 'true'
     return_value = add_image_to_deprecated_list(image_name, reason, file_path, verbose)
-    return return_value
+    print(return_value, int(return_value))
+    sys.exit(int(return_value))
 
 if __name__ == "__main__":
     main()

--- a/docker/boto3py3/Pipfile.lock
+++ b/docker/boto3py3/Pipfile.lock
@@ -18,19 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:3fb956d097105a0fb98c29a622ff233fa8de68519aabd7088d7ffd36dfc33214",
-                "sha256:b59a210fa6a87f0c755b40403ffc66b9b285680bbc5ad5245cf167e2def33620"
+                "sha256:15733c2bbedce7a36fcf1749560c72c3ee90785aa6302a98658c7bffdcbe1f2a",
+                "sha256:ea8ebcea4ccb70d1cf57526d9eec6012c76796f28ada3e9cc1d89178683d8107"
             ],
             "index": "pypi",
-            "version": "==1.23.7"
+            "version": "==1.23.8"
         },
         "botocore": {
             "hashes": [
-                "sha256:0f4a467188644382856e96e85bff0b453442d5cf0c0f554154571a6e2468a005",
-                "sha256:9f8d5e8d65b24d97fcb7804b84831e5627fceb52707167d2f496477675c98ded"
+                "sha256:620851daf1245af5bc28137aa821375bac964aa0eddc482437c783fe01e298fc",
+                "sha256:e786722cb14de7319331cc55e9092174de66a768559700ef656d05ff41b3e24f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.26.7"
+            "version": "==1.26.8"
         },
         "jmespath": {
             "hashes": [

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -154,7 +154,6 @@ function docker_build {
             return 1
         else
             echo "deprectaed no need to build"
-            return 0
         fi
     fi
 
@@ -174,6 +173,13 @@ function docker_build {
     cp Dockerfile "$tmp_dir/Dockerfile"
     echo "" >> "$tmp_dir/Dockerfile"
     echo "ENV DOCKER_IMAGE=$image_full_name" >> "$tmp_dir/Dockerfile"
+    
+    if [[ "$(prop 'deprecated')" ]]; then
+        echo "DEPRECATED_IMAGE=true" >> "$tmp_dir/Dockerfile"
+        reason=$(prop 'deprecated_reason')
+        echo "DEPRECATED_REASON=$reason"
+    fi
+
     docker build -f "$tmp_dir/Dockerfile" . -t ${image_full_name} \
         --label "org.opencontainers.image.authors=Demisto <containers@demisto.com>" \
         --label "org.opencontainers.image.version=${VERSION}" \

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -146,15 +146,9 @@ function docker_build {
     image_full_name="${DOCKER_ORG}/${image_name}:${VERSION}"
 
     if [[ "$(prop 'deprecated')" ]]; then
-        echo "${DOCKER_ORG}/${image_name} image is deprected, checking whethear the image is listed in the deprecated list or not"
-        reason=$(prop 'deprecated_reason')
-        
-        if ! ${PY3CMD} "${DOCKER_SRC_DIR}"/add_image_to_deprecated_or_internal_list.py "${DOCKER_ORG}"/"${image_name}" "${reason}" "${DOCKER_SRC_DIR}"/deprecated_images.json; then
-            echo "failed while handling deprected image"
-            return 1
-        else
-            echo "deprectaed no need to build"
-        fi
+        echo "${DOCKER_ORG}/${image_name} image is deprected, checking whether the image is listed in the deprecated list or not"
+        reason=$(prop 'deprecated_reason')        
+        ${PY3CMD} "${DOCKER_SRC_DIR}"/add_image_to_deprecated_or_internal_list.py "${DOCKER_ORG}"/"${image_name}" "${reason}" "${DOCKER_SRC_DIR}"/deprecated_images.json
     fi
 
     del_requirements=no
@@ -175,9 +169,9 @@ function docker_build {
     echo "ENV DOCKER_IMAGE=$image_full_name" >> "$tmp_dir/Dockerfile"
     
     if [[ "$(prop 'deprecated')" ]]; then
-        echo "DEPRECATED_IMAGE=true" >> "$tmp_dir/Dockerfile"
+        echo "ENV DEPRECATED_IMAGE=true" >> "$tmp_dir/Dockerfile"
         reason=$(prop 'deprecated_reason')
-        echo "DEPRECATED_REASON=$reason"
+        echo "ENV DEPRECATED_REASON=$reason" >> "$tmp_dir/Dockerfile"
     fi
 
     docker build -f "$tmp_dir/Dockerfile" . -t ${image_full_name} \

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -158,16 +158,6 @@ function docker_build {
         fi
     fi
 
-    if [[ "$(prop 'internalonly')" ]]; then
-        echo "${DOCKER_ORG}/${image_name} image is for intenal use only, checking whethear if the image is listed in the intelal list"
-        reason=$(prop 'internalonly_reason')
-        
-        if ! ${PY3CMD} "${DOCKER_SRC_DIR}"/add_image_to_deprecated_or_internal_list.py "${DOCKER_ORG}"/"${image_name}" "${reason}" "${DOCKER_SRC_DIR}"/internal_images.json; then
-            echo "failed while handling for internal use only image"
-            return 1        
-        fi
-    fi
-
     del_requirements=no
     if [ -f "Pipfile" -a ! -f "requirements.txt" ]; then
         if [ ! -f "Pipfile.lock" ]; then

--- a/docker/google-vision-api/Pipfile.lock
+++ b/docker/google-vision-api/Pipfile.lock
@@ -58,11 +58,11 @@
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:4527f7b8518a795624ab68da412d55628f83b98c67dd6a5d6edf725454f8b30b",
-                "sha256:600c43d7eac6e3536fdcad1d14ba9ee503edf4c7db0bd827e791bbf03b9f1330"
+                "sha256:629bbde991ce2d9697c6da37f2416f7aeb01ba01505b166066a415b3c3ce1dfc",
+                "sha256:7e172b06abeff7170108596446f0c8e56a129a40ef29a802270a02c0b07e993d"
             ],
             "index": "pypi",
-            "version": "==2.48.0"
+            "version": "==2.49.0"
         },
         "google-auth": {
             "hashes": [


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Content Pull Request
Related PR: 
[link to the PR at demisto/content](https://github.com/demisto/dockerfiles/pull/7666)

## Related Issues
Related: [CIAC-416](https://jira-hq.paloaltonetworks.local/browse/CIAC-416)

## Description
adding support for 2 couples of new key is the build.conf :
deprecated=true
deprectaed_reason="text message"
internalonly=true
internalonly_reason="text message"
the build script will handle the above key to maintains  2 list in the dockerfiles repo 
deprected_images.json: this file will contain all the deprecated docker images information
internal_images.json: this file will contain all the dockerimags information that are for internal use only
