### PR TITLE
chrome: add env variable for chrome exe path

### DIFF
--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -49,3 +49,5 @@ RUN apt-get update && apt-get -t bullseye-backports install -y --no-install-reco
   curl \
   unzip \
 && rm -rf /var/lib/apt/lists/*
+
+ENV CHROME_EXE="/opt/google/chrome/chrome"

--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -50,4 +50,4 @@ RUN apt-get update && apt-get -t bullseye-backports install -y --no-install-reco
   unzip \
 && rm -rf /var/lib/apt/lists/*
 
-ENV CHROME_EXE="/opt/google/chrome/chrome"
+ENV CHROME_EXE="/opt/google/chrome/google-chrome"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: link to the issue

## Description
Adding an env var of CHROME_EXE so it is clear where is the CHROME_EXE installed and allow smarter unit testing.