### PR TITLE
bumping pyPDF2 to 2.1.0 and fix missing dependencies for pikepdf

### DIFF
--- a/docker/readpdf/Pipfile
+++ b/docker/readpdf/Pipfile
@@ -8,6 +8,7 @@ verify_ssl = true
 [packages]
 pypdf2 = "*"
 pikepdf = "*"
+packaging = "*"
 
 [requires]
 python_version = "3.10"

--- a/docker/readpdf/Pipfile.lock
+++ b/docker/readpdf/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "943b3c9088fbba9d23901c5dc05084bba01d1a2be04db254ed5fa8ecd61193f2"
+            "sha256": "c96936b111a49c324a2acf555231548160cd68c91e386efecc0e9ec470d508e2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -85,37 +85,45 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.9.0"
         },
-        "pikepdf": {
+        "packaging": {
             "hashes": [
-                "sha256:0922ce13e144fcb78599d8e0890881891d2e3c8d30a40f19dc885c81618787dd",
-                "sha256:1298ace4778ce22b38195f630b72d7e3481f1603de44372082fa91cadd900344",
-                "sha256:3804e12d06ada0ed2d6ace4f2b12aa0cb3070976c945f240e588ec873e72d66a",
-                "sha256:382874f43b02206548d674f0f907466b2a128347ae1363f5700666c188a9a3a0",
-                "sha256:3ea607b53b6e6d839ecadad3938c225efbc7969fe7fc6939099ddf4e852e5605",
-                "sha256:41008bb006572af78e3136dc722e909c2384f50a193f684c3ff61657dfb84a56",
-                "sha256:418e6ec10bc3590d420c20f8c92b043f0e96d3b6ae5523bf2620f0e88b188127",
-                "sha256:48dc999589e162a82f24cf7be57844c77305e3add0fb3ad130cba6e4cb91a6b9",
-                "sha256:5f8e2219923ccdd7b9b389b685f5a55d25fb31283760616c3ffd680c77402b57",
-                "sha256:634289831fb9920deb251c37234aea6f51318b7e3b20b9c22b76fa1384598f79",
-                "sha256:785073df6a0c28c1f48443285111a3983e0723c7f734e39a3895dbbe9aaaede9",
-                "sha256:7b93cb71fe91a046cafe0480058933a881b76992f676363d5164bc9a102ba7b9",
-                "sha256:a6f454dcc922b1246e11014cd69ce871d60bdc95f22370e581f3ae4d37efc802",
-                "sha256:a740c0c14c8bb05221d6d7f87d20f186f50907b2b114531177b0d5733d6c01fd",
-                "sha256:ad36672a3df28f4120f9bafa15a07e003dde111847b2e7f55beeafa3b30afe7d",
-                "sha256:be4cfce43e7638d81cd0df2771ed76da9cf4b287bf27184c1d50ecbca28393af",
-                "sha256:bff70ddb8f5281fc144fbc58d78b496e69895308e42623b9457f23fcc1f0f638",
-                "sha256:c3c1702eda09acd9382d4d4bc7f82b478956e783337de4e518c8fdcff0ec1b68",
-                "sha256:cf65a8b28732db26399dad012faad0d393dda5ee228ee697ab8c207ae2b74070",
-                "sha256:d340349fb1f37449dee1b00c5717d087af6d68e62e1a1ec0436aa31f9d5466f6",
-                "sha256:e77ca97f0496da5797d5d2fdb5ed9e3f8ba41fc398dd1122be0c209c5eecfaa3",
-                "sha256:e811b1531712489417344155dea6920fcf71e7678b4fdd9ce8c8e51f695512c7",
-                "sha256:eab1090019cc1d77c4ffcab8ca4b646b348baed95bb74fdccbcda943e4954f7c",
-                "sha256:f819431f125c94b04b5fe9cb4a3c8bd20980cf971cfbdff88a38e55fc73f131f",
-                "sha256:f9d841a2e0a1f402c303876f7ad6d298c61a83faaf138073b57bfcc2f74a9ed4",
-                "sha256:fe33d7884fa2092d9d838acdd0ec00c8b0e4f6d77d7444fb2fbd4d44f79fe860"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
             "index": "pypi",
-            "version": "==5.1.4"
+            "version": "==21.3"
+        },
+        "pikepdf": {
+            "hashes": [
+                "sha256:0af747f989d0de8302e6e58e3da4c38d230bad6138b1cbb8dc6838e16285e63f",
+                "sha256:0bee8c97f4777ea21156850f7060e6cb20166956318d28a8b370bbdf61658ef9",
+                "sha256:10fa4d8e47dd91fb083c6d3ac1d2f7ba71552baebb0d019fd06295ed6e1becc8",
+                "sha256:19db48e67b71c22cd6c5bf0af5689e46708676763392d23a114c08b9b45e08ed",
+                "sha256:2324f0a651f0e3d0770bf13b5731ecbe33b48339f37e61eb1156ee44252a4d82",
+                "sha256:3226f44e421bb08b453a2071ac3114a2c3fba6975168dfb83f1d7d038c1e17c1",
+                "sha256:360f65e0662a903d28584166ab8587837c3d40737c245e60a9f9a856beacbbf1",
+                "sha256:436b7032cc8a78cb4653db7b43b21020563b75c59456f354a664b3fe2f9570cf",
+                "sha256:543a629a21552751cf30f2f56091256caa57dca79eb841926ecfdca88b386a67",
+                "sha256:56fdf2a4cb58cd200798a396ed0b93211b8eb67efbfe1f8d371a73fcafc3a615",
+                "sha256:58067c3d623ec41874b607c8451f64d3122a2cb5a2b862855830e0032bf6475f",
+                "sha256:5f2bd5616bf0faebefb81e7a8ce3b63ed5cab640183c330b31c95c18bb532ab6",
+                "sha256:646aa46e10e973e0045c9e4dd36928cfde0efa8c0a7b7853e18d8281db1ec8df",
+                "sha256:6541e6437a1bc6f115847ad33d9b5e94d10d4723b0c0566e3d3aacccffda81d1",
+                "sha256:680a7c04f23037c35a27967ab34d5fdc0c33b5f544228509f860373948f972af",
+                "sha256:6b14372d32d3c2f7027c4ccffd6e567a3caa6353a1a5dd30dcb9b3c6868cac5a",
+                "sha256:7320c6ca7e6436f4d4fb38006b23e915693a10b426840ded45264b9c7f752c0a",
+                "sha256:7dcd9c31cab21eed2aca3010ac2812e0daefab435a084630b61602821c5b4e80",
+                "sha256:87a556ff31695ede6e71f3576b3e153d1d8049ee411d38543cca8e51aeb2bedd",
+                "sha256:9569e624db7ac9497ccb91f9a60b93150e212b3e42e677ee1f8aef128fa74023",
+                "sha256:9d47d994ee2bc05d65be7c3c45c2d5e65698e0de2be90564719b9f851f906a42",
+                "sha256:ab2f60c5bdd56d7b47beb796fc00c8466112f2c060611cbb6f9a59b24b9dc8fc",
+                "sha256:b794198490d2ae9eb4c19c0396809b103eafe55130e9020014c3c3e2fa4fbf20",
+                "sha256:cedf182fb2687c127c6e2a4a1a83d9cc7ed1fcb3f75363d6c2f7846a1a346f41",
+                "sha256:e555aca634703db466be4f60d23850226efd575e94ca085b94ff34647ecb6b62",
+                "sha256:f7d8e20ee848626fb64585a59e5dcd8404b73afeaa7da86ba69867d7ca732283"
+            ],
+            "index": "pypi",
+            "version": "==5.1.5"
         },
         "pillow": {
             "hashes": [
@@ -161,13 +169,21 @@
             "markers": "python_version >= '3.7'",
             "version": "==9.1.1"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+            ],
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
+        },
         "pypdf2": {
             "hashes": [
-                "sha256:04ce42cd05707881fedbca3164744511805fe8c30618ae4cfb2b940e3368d5ad",
-                "sha256:7d80914ebb4cf93348d270f27a7a5eb741b912be63927da65c4c6b292c2f6b10"
+                "sha256:768a7128b60697187de776345e6f922913517f5f7deecca550dce8f901667599",
+                "sha256:99b9ea66107533f925d97325bdc0d9f2983c101831547627dbc6726c99081808"
             ],
             "index": "pypi",
-            "version": "==1.28.4"
+            "version": "==2.1.0"
         }
     },
     "develop": {}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Content Pull Request
https://github.com/py-pdf/PyPDF2/issues/925

## Related Issues
https://jira-hq.paloaltonetworks.local/browse/XSUP-13059

## Description
bumbing up to pyPDF2 2.1.0 and fix missing dependencies for pikepdf
