### PR TITLE
fix warning bug

### DIFF
--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -159,7 +159,7 @@ function docker_build {
             return 1
         fi
         pipenv --rm || echo "Proceeding. It is ok that no virtualenv is available to remove"
-        PIPENV_YES=yes pipenv lock -r --no-header> requirements.txt
+        PIPENV_YES=yes pipenv run pip freeze > requirements.txt
         echo "Pipfile lock generated requirements.txt: "
         cat requirements.txt
         # del_requirements=yes


### PR DESCRIPTION
We used to do `pipenv lock -r > requirements.txt`, which sometimes wrote warnings into the file, then installing the file [failed](https://app.circleci.com/pipelines/github/demisto/dockerfiles/24688/workflows/5dbe8e50-56b2-492e-a3f7-370c49532b54/jobs/30677) as the warnings obviously do not match the expected syntax of `requirements.txt`. 