### PR TITLE
fix bug

### DIFF
--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -159,9 +159,14 @@ function docker_build {
             return 1
         fi
         pipenv --rm || echo "Proceeding. It is ok that no virtualenv is available to remove"
-        PIPENV_YES=yes pipenv lock -r --no-header> requirements.txt
+        pipenv install
+        PIPENV_YES=yes pipenv run pip freeze > requirements.txt
         echo "Pipfile lock generated requirements.txt: "
+        echo "##########################################"
         cat requirements.txt
+        echo "##########################################"
+        [ ! -f requirements.txt ] && echo "requirements.txt does not exist!" && return 1
+        [ ! -s requirements.txt ] && echo "WARNING: requirements.txt is empty"
         # del_requirements=yes
     fi
 


### PR DESCRIPTION
## This is an improved (working) version of #7948 

We used to do pipenv lock -r > requirements.txt, which sometimes wrote warnings into the file, then installing the file [failed](https://app.circleci.com/pipelines/github/demisto/dockerfiles/24688/workflows/5dbe8e50-56b2-492e-a3f7-370c49532b54/jobs/30677) as the warnings obviously do not match the expected syntax of requirements.txt.

