### PR TITLE
py3-tools update version to 1.0.0

### DIFF
--- a/docker/py3-tools/Dockerfile
+++ b/docker/py3-tools/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM demisto/python3:3.10.4.28442
+FROM demisto/python3:3.10.4.30607
 
 COPY requirements.txt .
 

--- a/docker/py3-tools/build.conf
+++ b/docker/py3-tools/build.conf
@@ -1,1 +1,1 @@
-version=0.0.1
+version=1.0.0


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: link to the issue

## Description
py3-tools is prod and being used by integrations. Don't see a reason to have a `0.0.1` version.