### PR TITLE
Fixed problematic URL

### DIFF
--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -263,12 +263,12 @@ function docker_build {
 -------------------------
 
 Docker image [$image_full_name] has been saved as an artifact. It is available at the following link: 
-https://${REVISION}-161347705-gh.circle-artifacts.com/0/docker_images/$IMAGENAMESAVE.gz
+https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/docker_images/$IMAGENAMESAVE.gz
 
 Load it locally into docker by running:
 
 \`\`\`
-curl -L "https://${REVISION}-161347705-gh.circle-artifacts.com/0/docker_images/$IMAGENAMESAVE.gz" | gunzip | docker load
+curl -L "https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/docker_images/$IMAGENAMESAVE.gz" | gunzip | docker load
 \`\`\`
 
 --------------------------


### PR DESCRIPTION
## Status
Ready

## Description
As can be seen in [this](https://github.com/demisto/dockerfiles/pull/7990#issuecomment-1163011965) PR comment, the mentioned URL: `https://31607-161347705-gh.circle-artifacts.com/0/docker_images/devdemisto_armorblox:1.0.0.31607.tar.gz` seems to belong to an old CircleCI format and thus not is invalid. 
I have generated a new link and as can be seen in the [test PR](https://github.com/demisto/dockerfiles/pull/8081) I have created, the `Build Docker Images` [step](https://app.circleci.com/pipelines/github/demisto/dockerfiles/25589/workflows/b9bced26-9114-495e-b1ef-462e5637b3b2/jobs/31612/parallel-runs/0/steps/0-107) generates two links, the old one and the new one:
1) `https://31612-161347705-gh.circle-artifacts.com/0/docker_images/devdemisto_armorblox:1.0.0.31612.tar.gz`
2) `https://output.circle-artifacts.com/output/job/2e99c41a-cf86-4b81-9c6a-c02a1a621c9f/artifacts/0/docker_images/devdemisto_armorblox:1.0.0.31612.tar.gz`

Easy to see that the first is invalid where the second is valid.
