### PR TITLE
bump up the python3 docker image to be based on python 3.10.5 and alpine 3.16

### DIFF
--- a/docker/python3-deb/Dockerfile
+++ b/docker/python3-deb/Dockerfile
@@ -1,5 +1,5 @@
 # Last modified: Sun, 23 Jan 2022 10:42:29 +0000
-FROM python:3.10.4-slim-bullseye
+FROM python:3.10.5-slim-bullseye
 
 RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list
 

--- a/docker/python3-deb/build.conf
+++ b/docker/python3-deb/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.10.4
+version=3.10.5

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,5 +1,5 @@
 # Last modified: Thu, 06 Jan 2022 11:44:29 +0000
-FROM python:3.10.4-alpine3.15
+FROM python:3.10.5-alpine3.16
 
 # Upgrade all packages to latest
 RUN apk --update --no-cache upgrade

--- a/docker/python3/Pipfile.lock
+++ b/docker/python3/Pipfile.lock
@@ -244,7 +244,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "tldextract": {
@@ -260,7 +260,7 @@
                 "sha256:238e70234214138ed7b4e8a0fab0e5e13872edab3be586ab8198c407620e2ab9",
                 "sha256:8b536a8ec63dc0751342b3984193a3118f8fca2afe25752bb9b7fffd398552d3"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2022.1"
         },
         "tzlocal": {

--- a/docker/python3/build.conf
+++ b/docker/python3/build.conf
@@ -1,2 +1,2 @@
 # Name value properties to use while doing a build
-version=3.10.4
+version=3.10.5


### PR DESCRIPTION
bump up the python3 docker image to be based on python 3.10.5 and alpine 3.16

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready


## Description
bump up the python3 docker image to be based on python 3.10.5 and alpine 3.16
