### PR TITLE
bump up google chrome to 103.0.5060.134 to apply the following security

### DIFF
--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -1,4 +1,4 @@
-# Last modified: Wed, 06 Jul 2022 18:05:52 +0000
+# Last modified: Tue, 26 Jul 2022 12:15:35 +0000
 FROM demisto/python3-deb:3.10.4.27798
 
 COPY requirements.txt .


### PR DESCRIPTION
bump up google chrome to 103.0.5060.134 to apply the following security fixes https://chromereleases.googleblog.com/2022/07/stable-channel-update-for-desktop_19.html

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: link to the issue

## Description
bump up google chrome to 103.0.5060.134 to apply the following security fixes https://chromereleases.googleblog.com/2022/07/stable-channel-update-for-desktop_19.html