### PR TITLE
bump_up_google_chrome_to_104_0_5112_101

### DIFF
--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -1,4 +1,4 @@
-# Last modified: Wed, 06 Jul 2022 18:05:52 +0000
+# Last modified: Tue, 16 Aug 2022 21:15:10 +0000
 FROM demisto/python3-deb:3.10.4.27798
 
 COPY requirements.txt .


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready


## Description
bump_up_google_chrome_to_104_0_5112_101
secuirty fixes https://chromereleases.googleblog.com/2022/08/stable-channel-update-for-desktop_16.html
