### PR TITLE
update parse-email-files docker image

### DIFF
--- a/docker/parse-emails/Pipfile.lock
+++ b/docker/parse-emails/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "attrs": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.4.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
         },
         "cffi": {
             "hashes": [
@@ -203,10 +203,10 @@
         },
         "parse-emails": {
             "hashes": [
-                "sha256:fd01c63104287c7b7b1b01aa2952f76a2174707affec1b73a50adf4f84a87357"
+                "sha256:36ac2243e57a26ec4f512cb008069c679c9bd129d563b3536f529fedbdbde33b"
             ],
             "index": "pypi",
-            "version": "==0.0.10"
+            "version": "==0.0.11"
         },
         "pcodedmp": {
             "hashes": [
@@ -264,10 +264,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
-                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
+                "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197",
+                "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"
             ],
-            "version": "==2022.1"
+            "version": "==2022.2.1"
         },
         "rtfde": {
             "hashes": [
@@ -279,11 +279,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:0d33c374d41c7863419fc8f6c10bfe25b7b498aa34164d135c622e52580c6b16",
-                "sha256:c04b44a57a6265fe34a4a444e965884716d34bae963119a76353434d6f18e450"
+                "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82",
+                "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==63.2.0"
+            "version": "==65.3.0"
         },
         "tomli": {
             "hashes": [


### PR DESCRIPTION

## Status
Ready

## Related Content Pull Request
Related PR: [link to the PR at demisto/content](https://github.com/demisto/parse-emails/pull/35)

## Related Issues
[Related: [link to the issue](url)](fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-3803))

## Description
add support for embedded images in EML files.