### PR TITLE
fail fast false

### DIFF
--- a/.github/workflows/create-update-dockerfiles-PR.yml
+++ b/.github/workflows/create-update-dockerfiles-PR.yml
@@ -39,6 +39,7 @@ jobs:
     needs:
       - get_branches
     strategy:
+      fail-fast: false
       matrix:
         branches: ${{ fromJSON(needs.get_branches.outputs.branches) }}
     steps:
@@ -56,6 +57,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.CONTENT_BOT_TOKEN}}
         PR_URL: ${{ steps.open-pr.outputs.pr_url }}
+        if: ${{ steps.open-pr.outputs.pr_url }}
       run: |
         echo "Approving and merging"
         gh pr review --approve "$PR_URL"

--- a/.github/workflows/create-update-dockerfiles-PR.yml
+++ b/.github/workflows/create-update-dockerfiles-PR.yml
@@ -58,7 +58,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.CONTENT_BOT_TOKEN}}
         PR_URL: ${{ steps.open-pr.outputs.pr_url }}
-        if: ${{ steps.open-pr.outputs.pr_url }}
+      if: ${{ steps.open-pr.outputs.pr_url }}
       run: |
         echo "Approving and merging"
         gh pr review --approve "$PR_URL"

--- a/.github/workflows/create-update-dockerfiles-PR.yml
+++ b/.github/workflows/create-update-dockerfiles-PR.yml
@@ -39,6 +39,7 @@ jobs:
     needs:
       - get_branches
     strategy:
+      max-parallel: 2
       fail-fast: false
       matrix:
         branches: ${{ fromJSON(needs.get_branches.outputs.branches) }}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/In Progress/In Hold (Reason for hold)

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: link to the issue

## Description
fail fast -> if 1 job in the matrix fails, cancel them all. Defaults to true. 1 branch failing to open a pr shouldnt affect the others
There also might be times where its fine that it fails, like if the pr wont actually make an update. 
If it fails, we shouldnt try to approve and merge (the if added in the end)