### PR TITLE
add python3-ubi to ignored dockerfiles

### DIFF
--- a/utils/auto_dockerfile_update/autoupdate-config.json
+++ b/utils/auto_dockerfile_update/autoupdate-config.json
@@ -5,6 +5,11 @@
       "description" : "Library unrar is not yet available for alpine 3.16",
       "valid_until" : "30/09/2022",
       "permanent" : false
+    },
+    {
+      "name": "python3-ubi",
+      "description": "This image should not be automatically updated as its one of the base images for the py3-primary image",
+      "permanent" : true
     }
   ]
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
Related: https://jira-hq.paloaltonetworks.local/browse/CIAC-4669

## Description
ignore the python3-ubi for autoupdates as its a base image for the py3-primary image
