### PR TITLE
skip dependant-bot check if docker image is deprecated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,10 +70,6 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: pip
-    directory: /docker/gvault
-    schedule:
-      interval: daily
-  - package-ecosystem: pip
     directory: /docker/python_pancloud
     schedule:
       interval: daily

--- a/docker/gvault/build.conf
+++ b/docker/gvault/build.conf
@@ -1,1 +1,2 @@
 version=1.0.0
+deprecated=true

--- a/docker/verify_dependabot.sh
+++ b/docker/verify_dependabot.sh
@@ -20,10 +20,12 @@ for d in `find "$DOCKER_SRC_DIR" -maxdepth 1 -mindepth 1 -type d`; do
     if [[ ! $(grep -E '^devonly=true' $d/build.conf) ]]; then # skip devonly images
         if [ -f "$d/Pipfile" -o -f "$d/requirements.txt" ]; then
             if [[ ! $(grep -B 1 "/docker/${name}\$" "$DEPENDABOT_CONFIG" | grep "package-ecosystem: pip") ]]; then
-                echo "=============================="
-                echo "Failed verifying python config for: [$d] in .github/dependabot.yml"
-                echo "To add the config run: ./docker/add_dependabot.sh docker/$name"
-                exit 2
+                if [[ ! "$(prop 'deprecated')" ]]; then
+                  echo "=============================="
+                  echo "Failed verifying python config for: [$d] in .github/dependabot.yml"
+                  echo "To add the config run: ./docker/add_dependabot.sh docker/$name"
+                  exit 2
+              fi
             fi
         fi
     fi


### PR DESCRIPTION

## Status
Ready

## Related Issues
Related: link to the issue

## Description
Skip the check that docker image should be added to dependent-bot if the docker image is deprecated
