### PR TITLE
Py3ews - Activated the legacy section in the openssl.cnf

### DIFF
--- a/docker/crypto/verify.py
+++ b/docker/crypto/verify.py
@@ -1,13 +1,12 @@
 from cryptography.fernet import Fernet
 import msal
+import hashlib
 from bs4 import BeautifulSoup
 # Make sure cryptograph works
 key = Fernet.generate_key()
 
 # Make sure MD4 is enabled:
-import hashlib
-hashlib.algorithms_available
-assert 'md4' in hashlib.algorithms_available
+hashlib.new('md4', b"text")
 
 print("All is good. cryptography generated a key: {}".format(key))
 print(msal.oauth2cli.assertion.JwtAssertionCreator('', 'All is good. msal was imported successfully').algorithm)

--- a/docker/crypto/verify.py
+++ b/docker/crypto/verify.py
@@ -3,5 +3,11 @@ import msal
 from bs4 import BeautifulSoup
 # Make sure cryptograph works
 key = Fernet.generate_key()
+
+# Make sure MD4 is enabled:
+import hashlib
+hashlib.algorithms_available
+assert 'md4' in hashlib.algorithms_available
+
 print("All is good. cryptography generated a key: {}".format(key))
 print(msal.oauth2cli.assertion.JwtAssertionCreator('', 'All is good. msal was imported successfully').algorithm)

--- a/docker/crypto/verify.py
+++ b/docker/crypto/verify.py
@@ -6,6 +6,8 @@ from bs4 import BeautifulSoup
 key = Fernet.generate_key()
 
 # Make sure MD4 is enabled:
+hashlib.algorithms_available
+assert 'md4' in hashlib.algorithms_available
 hashlib.new('md4', b"text")
 
 print("All is good. cryptography generated a key: {}".format(key))

--- a/docker/crypto/verify.py
+++ b/docker/crypto/verify.py
@@ -1,14 +1,7 @@
 from cryptography.fernet import Fernet
 import msal
-import hashlib
 from bs4 import BeautifulSoup
 # Make sure cryptograph works
 key = Fernet.generate_key()
-
-# Make sure MD4 is enabled:
-hashlib.algorithms_available
-assert 'md4' in hashlib.algorithms_available
-hashlib.new('md4', b"text")
-
 print("All is good. cryptography generated a key: {}".format(key))
 print(msal.oauth2cli.assertion.JwtAssertionCreator('', 'All is good. msal was imported successfully').algorithm)

--- a/docker/py3ews/Dockerfile
+++ b/docker/py3ews/Dockerfile
@@ -12,7 +12,7 @@ RUN apk --update add --no-cache libxslt-dev \
 RUN cp /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf.org \
 && sed -i '/default = default_sect/a legacy = legacy_sect' /etc/ssl/openssl.cnf \
 && echo -e 'activate = 1\n\n[legacy_sect]\nactivate = 1\n' > /tmp/ssl.cnf \
-&& sed -i '/ activate = 1/r /tmp/ssl.cnf' /etc/ssl/openssl.cnf \
+&& sed -i '/\[default_sect\]/r /tmp/ssl.cnf' /etc/ssl/openssl.cnf \
 && sed -i '/# activate = 1/d' /etc/ssl/openssl.cnf \
 && rm /tmp/ssl.cnf \
 && grep 'legacy_sect' /etc/ssl/openssl.cnf

--- a/docker/py3ews/Dockerfile
+++ b/docker/py3ews/Dockerfile
@@ -6,3 +6,13 @@ RUN apk --update add --no-cache libxslt-dev \
   && apk --update add --no-cache --virtual .build-dependencies python3-dev gcc build-base wget git libffi-dev openssl-dev python3-dev libxml2-dev \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del .build-dependencies
+
+# Handling the issue described here: https://github.com/ecederstrand/exchangelib/issues/608
+# by activating the legacy sect in openssl.cnf (re-enableing md4 to hashlib)
+RUN cp /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf.org \
+&& sed -i '/default = default_sect/a legacy = legacy_sect' /etc/ssl/openssl.cnf \
+&& echo -e 'activate = 1\n\n[legacy_sect]\nactivate = 1\n' > /tmp/ssl.cnf \
+&& sed -i '/ activate = 1/r /tmp/ssl.cnf' /etc/ssl/openssl.cnf \
+&& sed -i '/# activate = 1/d' /etc/ssl/openssl.cnf \
+&& rm /tmp/ssl.cnf \
+&& grep 'legacy_sect' /etc/ssl/openssl.cnf

--- a/docker/py3ews/verify.py
+++ b/docker/py3ews/verify.py
@@ -27,6 +27,13 @@ from exchangelib import IMPERSONATION, DELEGATE, Account, Credentials, \
 from exchangelib.version import EXCHANGE_2007, EXCHANGE_2010, EXCHANGE_2010_SP2, EXCHANGE_2013, EXCHANGE_2016
 from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
 import tzlocal
+import hashlib
 
 test = tzlocal.get_localzone()
+
+# Make sure MD4 is enabled:
+hashlib.algorithms_available
+assert 'md4' in hashlib.algorithms_available
+hashlib.new('md4', b"text")
+
 print('all is good, `get_localzone() -> {}` is working'.format(test))


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready (Reason for hold)

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Two bugs:
Related: [XSUP-20359](https://jira-hq.paloaltonetworks.local/browse/XSUP-20359),
Related: [XSUP-20247](https://jira-hq.paloaltonetworks.local/browse/XSUP-20247).

An old bug that I think is also related: 
[XSUP-19122](https://jira-hq.paloaltonetworks.local/browse/XSUP-19122).

## Description
In the above mention bugs, EWS Mail Sender integration failed after upgrading the docker image to: demisto/py3ews:1.0.0.43044. 
The error in the logs is: 
```
  File "/usr/local/lib/python3.10/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type md4
```
It appears that some hashing algorithms with MD4 among them were disabled as obsoleted, which caused that error. 
To solve that we activated the legacy section in the openssl.cnf file (re-enabled md4 to hashlib) - based on the solution described here: https://github.com/ecederstrand/exchangelib/issues/608.


