### PR TITLE
py-ews - Added check that md4 is enabled to verify.py

### DIFF
--- a/docker/py-ews/verify.py
+++ b/docker/py-ews/verify.py
@@ -39,3 +39,8 @@ res.raise_for_status()
 
 # verify dateaparser works. We had a case that it failed with timezone issues
 dateparser.parse("10 minutes")
+
+# Make sure MD4 is enabled:
+hashlib.algorithms_available
+assert 'md4' in hashlib.algorithms_available
+hashlib.new('md4', b"text")


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Content Pull Request
Related PR: [11572](https://github.com/demisto/dockerfiles/pull/11572).

## Description
As we did in py3ews, I added a check to the verify.py of the py-ews image to make sure that the MD4 is enabled. 
That way we should catch problems in future upgrades. 
