### PR TITLE
py3-native dependant bot fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -678,7 +678,7 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: pip
-    directory: /docker/python3-native
+    directory: /docker/py3-native
     schedule:
       interval: daily
   - package-ecosystem: pip


### PR DESCRIPTION
## Status
Ready

## Description
Fixed an issue where py3-native wasn't defined correctly in dependant bot config
