### PR TITLE
ignore deprecated dockers in auto-update

### DIFF
--- a/utils/auto_dockerfile_update/get_dockerfiles.py
+++ b/utils/auto_dockerfile_update/get_dockerfiles.py
@@ -106,7 +106,7 @@ def filter_ignored_files(files_list):
 def get_docker_files(base_path="docker/", devonly=False, external=False, internal=False) -> List[Dict]:
     """
     Get all the relevant dockerfiles from the repository.
-    
+
     Args:
         base_path (str): base path for docker files
         devonly (bool): whether or not to get devonly images
@@ -122,12 +122,9 @@ def get_docker_files(base_path="docker/", devonly=False, external=False, interna
     for path in dockerfiles_paths:
         dockerfile_dir_path = path.replace("/Dockerfile", "")
         build_conf_content = read_build_conf(dockerfile_dir_path)  # if does not exist will default to empty string
-        if is_dev_only(build_conf_content) and not devonly:
+        if (is_dev_only(build_conf_content) and not devonly) or is_docker_deprecated(build_conf_content):
             continue
-
-        if is_docker_deprecated(build_conf_content):
-            continue
-
+            
         with open(path) as f:
             docker_file_content = f.read()
             base_image = re.search(BASE_IMAGE_REGEX, docker_file_content)

--- a/utils/auto_dockerfile_update/get_dockerfiles.py
+++ b/utils/auto_dockerfile_update/get_dockerfiles.py
@@ -124,11 +124,11 @@ def get_docker_files(base_path="docker/", devonly=False, external=False, interna
         build_conf_content = read_build_conf(dockerfile_dir_path)  # if does not exist will default to empty string
 
         if is_docker_deprecated(build_conf_content):
-            print(f"docker {dockerfile_dir_path} is deprecated")
+            print(f"docker {dockerfile_dir_path} is deprecated, hence not updating it")
             continue
 
         if is_dev_only(build_conf_content) and not devonly:
-            print(f"docker {dockerfile_dir_path} is dev-only")
+            print(f"docker {dockerfile_dir_path} is dev-only, hence not updating it")
 
         with open(path) as f:
             docker_file_content = f.read()

--- a/utils/auto_dockerfile_update/get_dockerfiles.py
+++ b/utils/auto_dockerfile_update/get_dockerfiles.py
@@ -122,9 +122,14 @@ def get_docker_files(base_path="docker/", devonly=False, external=False, interna
     for path in dockerfiles_paths:
         dockerfile_dir_path = path.replace("/Dockerfile", "")
         build_conf_content = read_build_conf(dockerfile_dir_path)  # if does not exist will default to empty string
-        if (is_dev_only(build_conf_content) and not devonly) or is_docker_deprecated(build_conf_content):
+
+        if is_docker_deprecated(build_conf_content):
+            print(f"docker {dockerfile_dir_path} is deprecated")
             continue
-            
+
+        if is_dev_only(build_conf_content) and not devonly:
+            print(f"docker {dockerfile_dir_path} is dev-only")
+
         with open(path) as f:
             docker_file_content = f.read()
             base_image = re.search(BASE_IMAGE_REGEX, docker_file_content)

--- a/utils/auto_dockerfile_update/get_dockerfiles.py
+++ b/utils/auto_dockerfile_update/get_dockerfiles.py
@@ -129,6 +129,7 @@ def get_docker_files(base_path="docker/", devonly=False, external=False, interna
 
         if is_dev_only(build_conf_content) and not devonly:
             print(f"docker {dockerfile_dir_path} is dev-only, hence not updating it")
+            continue
 
         with open(path) as f:
             docker_file_content = f.read()

--- a/utils/auto_dockerfile_update/get_dockerfiles.py
+++ b/utils/auto_dockerfile_update/get_dockerfiles.py
@@ -4,8 +4,10 @@ import re
 from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
-
+from configparser import ConfigParser, MissingSectionHeaderError
 from dateutil.parser import parse
+
+
 BASE_IMAGE_REGEX = re.compile(r"(?:FROM [\S]+)")
 INTERNAL_BASE_IMAGES = re.compile(r"(demisto\/|devdemisto\/)")
 LAST_MODIFIED_REGEX = re.compile(r"# Last modified: [^\n]*")
@@ -49,43 +51,29 @@ def parse_base_image(full_base_image_name: str) -> (str, str, str):
     return repository, image_name, tag
 
 
-def read_build_conf(dockerfile_path: str) -> str:
+def read_build_conf(dockerfile_path: str) -> Dict:
     """
-    Reads the build conf and return its content
+    Reads the build conf and return its content as a dict.
+
+    Returns:
+        dict: where the keys are the key name in conf and its value.
     """
     build_conf_path = f"{dockerfile_path}/build.conf"
     try:
         with open(build_conf_path) as f:
-            return f.read()
+            build_conf_content = f.read()
+
+        build_conf_parser = ConfigParser()
+        build_conf_parser.read_string(f'[config]\n{build_conf_content}')
+        return dict(build_conf_parser['config'])
+
     except FileNotFoundError:
         print(f'Could not find the file {build_conf_path}')
-        return ''
+        return {}
 
-
-def is_dev_only(build_conf_content: str) -> bool:
-    """
-    Check the build.conf for "devonly" flag.
-
-    Args:
-        build_conf_content (str): build conf content
-
-    Returns:
-        bool: True if the docker is dev only, False if not.
-    """
-    return "devonly=true" in build_conf_content
-
-
-def is_docker_deprecated(build_conf_content: str):
-    """
-    Check the build.conf for "deprecated" flag.
-
-    Args:
-        build_conf_content (str): build conf content
-
-    Returns:
-        bool: True if the docker is deprecated, False if not.
-    """
-    return "deprecated=true" in build_conf_content
+    except MissingSectionHeaderError as error:
+        print(f'Could not parse {build_conf_path}, {error=}')
+        return {}
 
 
 def filter_ignored_files(files_list):
@@ -123,11 +111,13 @@ def get_docker_files(base_path="docker/", devonly=False, external=False, interna
         dockerfile_dir_path = path.replace("/Dockerfile", "")
         build_conf_content = read_build_conf(dockerfile_dir_path)  # if does not exist will default to empty string
 
-        if is_docker_deprecated(build_conf_content):
+        # skip if the docker is deprecated
+        if build_conf_content.get('deprecated') == 'true':
             print(f"docker {dockerfile_dir_path} is deprecated, hence not updating it")
             continue
 
-        if is_dev_only(build_conf_content) and not devonly:
+        # skip if the docker is only used for dev
+        if build_conf_content.get('devonly') == 'true' and not devonly:
             print(f"docker {dockerfile_dir_path} is dev-only, hence not updating it")
             continue
 

--- a/utils/auto_dockerfile_update/get_dockerfiles.py
+++ b/utils/auto_dockerfile_update/get_dockerfiles.py
@@ -49,26 +49,43 @@ def parse_base_image(full_base_image_name: str) -> (str, str, str):
     return repository, image_name, tag
 
 
-def is_dev_only(dockerfile_path=str) -> bool:
+def read_build_conf(dockerfile_path: str) -> str:
+    """
+    Reads the build conf and return its content
+    """
+    build_conf_path = f"{dockerfile_path}/build.conf"
+    try:
+        with open(build_conf_path) as f:
+            return f.read()
+    except FileNotFoundError:
+        print(f'Could not find the file {build_conf_path}')
+        return ''
+
+
+def is_dev_only(build_conf_content: str) -> bool:
     """
     Check the build.conf for "devonly" flag.
+
     Args:
-        dockerfile_path (str): the dockerfile's path
+        build_conf_content (str): build conf content
 
     Returns:
-
+        bool: True if the docker is dev only, False if not.
     """
-    path = f"{dockerfile_path}/build.conf"
-    try:
-        with open(path) as f:
-            content = f.read()
-            if "devonly=true" in content:
-                return True
+    return "devonly=true" in build_conf_content
 
-    except FileNotFoundError:
-        return False
 
-    return False
+def is_docker_deprecated(build_conf_content: str):
+    """
+    Check the build.conf for "deprecated" flag.
+
+    Args:
+        build_conf_content (str): build conf content
+
+    Returns:
+        bool: True if the docker is deprecated, False if not.
+    """
+    return "deprecated=true" in build_conf_content
 
 
 def filter_ignored_files(files_list):
@@ -89,6 +106,7 @@ def filter_ignored_files(files_list):
 def get_docker_files(base_path="docker/", devonly=False, external=False, internal=False) -> List[Dict]:
     """
     Get all the relevant dockerfiles from the repository.
+    
     Args:
         base_path (str): base path for docker files
         devonly (bool): whether or not to get devonly images
@@ -103,7 +121,11 @@ def get_docker_files(base_path="docker/", devonly=False, external=False, interna
 
     for path in dockerfiles_paths:
         dockerfile_dir_path = path.replace("/Dockerfile", "")
-        if is_dev_only(dockerfile_dir_path) and not devonly:
+        build_conf_content = read_build_conf(dockerfile_dir_path)  # if does not exist will default to empty string
+        if is_dev_only(build_conf_content) and not devonly:
+            continue
+
+        if is_docker_deprecated(build_conf_content):
             continue
 
         with open(path) as f:

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -87,7 +87,7 @@ def update_external_base_dockerfiles(git_repo: Repo, no_timestamp_updates=True) 
 
         if is_docker_file_outdated(file, latest_tag_name, latest_tag_last_updated, no_timestamp_updates):
             branch_name = fr"autoupdate/Update_{file['repo']}_{file['image_name']}_from_{file['tag']}_to_{latest_tag_name}"
-            # update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
+            update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
             print(f"Updated {file['path']}")
 
 
@@ -134,7 +134,7 @@ def update_internal_base_dockerfile(git_repo: Repo) -> None:
         for batch_slice in batch(outdated_files, BATCH_SIZE):
             image_names = reduce(lambda a, b: f"{a}-{b}", [file['name'] for file in batch_slice])
             branch_name = fr"autoupdate/{base_image}_{image_names}_{latest_tag_name}"
-            # update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
+            update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
 
 
 def update_and_push_dockerfiles(git_repo: Repo, branch_name: str, files: List[Dict], latest_tag_name: str) -> None:

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -26,7 +26,7 @@ def is_docker_file_outdated(dockerfile: Dict, latest_tag: str, last_updated: str
     Returns:
         True if the latest tag is newer or the latest tag is the same but new updates
     """
-    print(f'checking if dockerfile {dockerfile.get("path")} is outdated')
+    print(f'Checking if dockerfile {dockerfile.get("path")} is outdated')
     current_tag = dockerfile['tag']
     current_tag_version = parse_versions(current_tag)
     latest_tag_version = parse_versions(latest_tag)
@@ -87,7 +87,7 @@ def update_external_base_dockerfiles(git_repo: Repo, no_timestamp_updates=True) 
 
         if is_docker_file_outdated(file, latest_tag_name, latest_tag_last_updated, no_timestamp_updates):
             branch_name = fr"autoupdate/Update_{file['repo']}_{file['image_name']}_from_{file['tag']}_to_{latest_tag_name}"
-            # update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
+            update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
             print(f"Updated {file['path']}")
 
 
@@ -134,7 +134,7 @@ def update_internal_base_dockerfile(git_repo: Repo) -> None:
         for batch_slice in batch(outdated_files, BATCH_SIZE):
             image_names = reduce(lambda a, b: f"{a}-{b}", [file['name'] for file in batch_slice])
             branch_name = fr"autoupdate/{base_image}_{image_names}_{latest_tag_name}"
-            # update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
+            update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
 
 
 def update_and_push_dockerfiles(git_repo: Repo, branch_name: str, files: List[Dict], latest_tag_name: str) -> None:

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -33,7 +33,7 @@ def is_docker_file_outdated(dockerfile: Dict, latest_tag: str, last_updated: str
     if current_tag_version < latest_tag_version:
         return True
     elif current_tag == latest_tag and not no_timestamp_updates:
-        print(f'{dateutil.parser.parse(last_updated)=}, {dateutil.parser.parse(dockerfile.get("last_modified"))=}')
+        print(f'{dateutil.parser.parse(last_updated)=}, {dateutil.parser.parse(dockerfile.get("last_modified"))=}, {dockerfile=}')
         if last_updated and dateutil.parser.parse(last_updated) > dateutil.parser.parse(
                 dockerfile.get('last_modified')):
             # if the latest tag update date is newer than the dockerfile

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -33,7 +33,6 @@ def is_docker_file_outdated(dockerfile: Dict, latest_tag: str, last_updated: str
     if current_tag_version < latest_tag_version:
         return True
     elif current_tag == latest_tag and not no_timestamp_updates:
-        # print(f'{dateutil.parser.parse(last_updated)=}, {dateutil.parser.parse(dockerfile.get("last_modified"))=}')
         if last_updated and dateutil.parser.parse(last_updated) > dateutil.parser.parse(
                 dockerfile.get('last_modified')):
             # if the latest tag update date is newer than the dockerfile
@@ -88,7 +87,7 @@ def update_external_base_dockerfiles(git_repo: Repo, no_timestamp_updates=True) 
 
         if is_docker_file_outdated(file, latest_tag_name, latest_tag_last_updated, no_timestamp_updates):
             branch_name = fr"autoupdate/Update_{file['repo']}_{file['image_name']}_from_{file['tag']}_to_{latest_tag_name}"
-            # update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
+            update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
             print(f"Updated {file['path']}")
 
 
@@ -135,7 +134,7 @@ def update_internal_base_dockerfile(git_repo: Repo) -> None:
         for batch_slice in batch(outdated_files, BATCH_SIZE):
             image_names = reduce(lambda a, b: f"{a}-{b}", [file['name'] for file in batch_slice])
             branch_name = fr"autoupdate/{base_image}_{image_names}_{latest_tag_name}"
-            # update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
+            update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
 
 
 def update_and_push_dockerfiles(git_repo: Repo, branch_name: str, files: List[Dict], latest_tag_name: str) -> None:

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -33,6 +33,7 @@ def is_docker_file_outdated(dockerfile: Dict, latest_tag: str, last_updated: str
     if current_tag_version < latest_tag_version:
         return True
     elif current_tag == latest_tag and not no_timestamp_updates:
+        print(f'{dateutil.parse(last_updated)=}, {dateutil.parser.parse(dockerfile.get("last_modified"))=}')
         if last_updated and dateutil.parser.parse(last_updated) > dateutil.parser.parse(
                 dockerfile.get('last_modified')):
             # if the latest tag update date is newer than the dockerfile

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -88,7 +88,7 @@ def update_external_base_dockerfiles(git_repo: Repo, no_timestamp_updates=True) 
 
         if is_docker_file_outdated(file, latest_tag_name, latest_tag_last_updated, no_timestamp_updates):
             branch_name = fr"autoupdate/Update_{file['repo']}_{file['image_name']}_from_{file['tag']}_to_{latest_tag_name}"
-            update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
+            # update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
             print(f"Updated {file['path']}")
 
 
@@ -135,7 +135,7 @@ def update_internal_base_dockerfile(git_repo: Repo) -> None:
         for batch_slice in batch(outdated_files, BATCH_SIZE):
             image_names = reduce(lambda a, b: f"{a}-{b}", [file['name'] for file in batch_slice])
             branch_name = fr"autoupdate/{base_image}_{image_names}_{latest_tag_name}"
-            update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
+            # update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
 
 
 def update_and_push_dockerfiles(git_repo: Repo, branch_name: str, files: List[Dict], latest_tag_name: str) -> None:

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -33,7 +33,7 @@ def is_docker_file_outdated(dockerfile: Dict, latest_tag: str, last_updated: str
     if current_tag_version < latest_tag_version:
         return True
     elif current_tag == latest_tag and not no_timestamp_updates:
-        print(f'{dateutil.parse(last_updated)=}, {dateutil.parser.parse(dockerfile.get("last_modified"))=}')
+        print(f'{dateutil.parse(last_updated)=}, {dateutil.parse(dockerfile.get("last_modified"))=}')
         if last_updated and dateutil.parser.parse(last_updated) > dateutil.parser.parse(
                 dockerfile.get('last_modified')):
             # if the latest tag update date is newer than the dockerfile

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -33,7 +33,7 @@ def is_docker_file_outdated(dockerfile: Dict, latest_tag: str, last_updated: str
     if current_tag_version < latest_tag_version:
         return True
     elif current_tag == latest_tag and not no_timestamp_updates:
-        print(f'{dateutil.parse(last_updated)=}, {dateutil.parse(dockerfile.get("last_modified"))=}')
+        print(f'{dateutil.parser.parse(last_updated)=}, {dateutil.parser.parse(dockerfile.get("last_modified"))=}')
         if last_updated and dateutil.parser.parse(last_updated) > dateutil.parser.parse(
                 dockerfile.get('last_modified')):
             # if the latest tag update date is newer than the dockerfile

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -33,7 +33,7 @@ def is_docker_file_outdated(dockerfile: Dict, latest_tag: str, last_updated: str
     if current_tag_version < latest_tag_version:
         return True
     elif current_tag == latest_tag and not no_timestamp_updates:
-        print(f'{dateutil.parser.parse(last_updated)=}, {dateutil.parser.parse(dockerfile.get("last_modified"))=}, {dockerfile=}')
+        # print(f'{dateutil.parser.parse(last_updated)=}, {dateutil.parser.parse(dockerfile.get("last_modified"))=}')
         if last_updated and dateutil.parser.parse(last_updated) > dateutil.parser.parse(
                 dockerfile.get('last_modified')):
             # if the latest tag update date is newer than the dockerfile

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -26,7 +26,7 @@ def is_docker_file_outdated(dockerfile: Dict, latest_tag: str, last_updated: str
     Returns:
         True if the latest tag is newer or the latest tag is the same but new updates
     """
-
+    print(f'checking if dockerfile {dockerfile.get("path")} is outdated')
     current_tag = dockerfile['tag']
     current_tag_version = parse_versions(current_tag)
     latest_tag_version = parse_versions(latest_tag)
@@ -87,7 +87,7 @@ def update_external_base_dockerfiles(git_repo: Repo, no_timestamp_updates=True) 
 
         if is_docker_file_outdated(file, latest_tag_name, latest_tag_last_updated, no_timestamp_updates):
             branch_name = fr"autoupdate/Update_{file['repo']}_{file['image_name']}_from_{file['tag']}_to_{latest_tag_name}"
-            update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
+            # update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
             print(f"Updated {file['path']}")
 
 
@@ -134,7 +134,7 @@ def update_internal_base_dockerfile(git_repo: Repo) -> None:
         for batch_slice in batch(outdated_files, BATCH_SIZE):
             image_names = reduce(lambda a, b: f"{a}-{b}", [file['name'] for file in batch_slice])
             branch_name = fr"autoupdate/{base_image}_{image_names}_{latest_tag_name}"
-            update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
+            # update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
 
 
 def update_and_push_dockerfiles(git_repo: Repo, branch_name: str, files: List[Dict], latest_tag_name: str) -> None:
@@ -149,7 +149,7 @@ def update_and_push_dockerfiles(git_repo: Repo, branch_name: str, files: List[Di
     Returns:
 
     """
-    print(f"Creating new branch: {branch_name}")
+    print(f"Trying to create new branch: {branch_name}")
     original_branch = git_repo.active_branch
     if branch_name in git_repo.git.branch("--all"):
         print("Branch already exits.")
@@ -164,6 +164,7 @@ def update_and_push_dockerfiles(git_repo: Repo, branch_name: str, files: List[Di
         git_repo.git.add("*")
         git_repo.git.commit(m=f"Update Dockerfiles")
         git_repo.git.push('--set-upstream', 'origin', branch)
+        print(f'Created branch {branch_name} successfully')
     except GitCommandError as e:
         print(f"Error creating {branch_name}")
         print(e)

--- a/utils/auto_dockerfile_update/update_dockerfiles.py
+++ b/utils/auto_dockerfile_update/update_dockerfiles.py
@@ -87,7 +87,7 @@ def update_external_base_dockerfiles(git_repo: Repo, no_timestamp_updates=True) 
 
         if is_docker_file_outdated(file, latest_tag_name, latest_tag_last_updated, no_timestamp_updates):
             branch_name = fr"autoupdate/Update_{file['repo']}_{file['image_name']}_from_{file['tag']}_to_{latest_tag_name}"
-            update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
+            # update_and_push_dockerfiles(git_repo, branch_name, [file], latest_tag_name)
             print(f"Updated {file['path']}")
 
 
@@ -134,7 +134,7 @@ def update_internal_base_dockerfile(git_repo: Repo) -> None:
         for batch_slice in batch(outdated_files, BATCH_SIZE):
             image_names = reduce(lambda a, b: f"{a}-{b}", [file['name'] for file in batch_slice])
             branch_name = fr"autoupdate/{base_image}_{image_names}_{latest_tag_name}"
-            update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
+            # update_and_push_dockerfiles(git_repo, branch_name, batch_slice, latest_tag_name)
 
 
 def update_and_push_dockerfiles(git_repo: Repo, branch_name: str, files: List[Dict], latest_tag_name: str) -> None:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
Related: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5002)

## Description
1) Do not auto update deprecated dockers in the auto-update process.
2) add more prints/logs for future issues
