### PR TITLE
py3-native: update libreoffice to 7.5.3

### DIFF
--- a/docker/py3-native/CHANGELOG.md
+++ b/docker/py3-native/CHANGELOG.md
@@ -1,6 +1,7 @@
 # py3-native Changelog
 
 ## Unreleased
+* Updated the *LibreOffice* to the following version: **7.5.3**
 
 ## 8.2.0
 * Updated py3-native to be based on ubi-9.1.

--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -58,7 +58,7 @@ RUN dnf update --nodocs -y  \
     && rm -rf /var/cache/dnf
 
 ARG LIBRE_OFFICE_MAJOR_VERSION=7.5
-ARG LIBRE_OFFICE_FULL_VERSION=${LIBRE_OFFICE_MAJOR_VERSION}.1
+ARG LIBRE_OFFICE_FULL_VERSION=${LIBRE_OFFICE_MAJOR_VERSION}.3
 ARG LIBRE_OFFICE_INSTALLATION_FILE_NAME=LibreOffice_${LIBRE_OFFICE_FULL_VERSION}_Linux_x86-64_rpm
 # libre-office mirrors are taken from here - http://download.documentfoundation.org/libreoffice/stable/
 


### PR DESCRIPTION

## Status
Ready

## Description
Fixes the issue in the `docker build` for the py3-native where the libreoffice 7.5.1 is not found anymore in the mirror.

https://app.circleci.com/pipelines/github/demisto/dockerfiles/51683/workflows/4d5a5c95-e47a-437c-96a2-3fe6d1cb0f43/jobs/57775