### PR TITLE
add iproute to py3-native for DockerHardeningCheck

### DIFF
--- a/docker/py3-native/CHANGELOG.md
+++ b/docker/py3-native/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Locked the installation of the *clang* package to version 14 due to dependency conflicts with the *tigervnc-server-minimal* package.
 * Locked the installation of the *rust* package to version 1.62 due to dependency conflicts with the *tigervnc-server-minimal* package.
 * Updated the *LibreOffice* to the following version: **7.5.3**
-* Added the *iproute* command to allow support for the **DockerHardeningCheck** script.
+* Added the *iproute* library to allow support for the **DockerHardeningCheck** script.
 
 ## 8.2.0
 * Updated py3-native to be based on ubi-9.1.

--- a/docker/py3-native/CHANGELOG.md
+++ b/docker/py3-native/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 * Updated the *LibreOffice* to the following version: **7.5.3**
-* Added the *iproute* command for the **DockerHardeningCheck** script.
+* Added the *iproute* command to allow support for the **DockerHardeningCheck** script.
 
 ## 8.2.0
 * Updated py3-native to be based on ubi-9.1.

--- a/docker/py3-native/CHANGELOG.md
+++ b/docker/py3-native/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Updated the *LibreOffice* to the following version: **7.5.3**
+* Added the *iproute* command for the **DockerHardeningCheck** script.
 
 ## 8.2.0
 * Updated py3-native to be based on ubi-9.1.

--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -25,7 +25,7 @@ RUN dnf update --nodocs -y  \
     && wget https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official \
     && rpm --import RPM-GPG-KEY-CentOS-Official \
     && mv repos/* /etc/yum.repos.d/ \
-    && dnf install -y --nodocs python3-devel gcc gcc-c++ make wget git unzip llvm-libs libXpm \
+    && dnf install -y --nodocs python3-devel gcc gcc-c++ make wget git unzip llvm-libs libXpm iproute \
     && dnf install -y --nodocs --enablerepo=$ROCKY_BASE --enablerepo=$ROCKY_RELEASE tigervnc-server-minimal xorg-x11-utils google-chrome-stable \
     && dnf install -y --nodocs --enablerepo=$ROCKY_BASE --enablerepo=$ROCKY_RELEASE --enablerepo=$FEDORA_EPEL ImageMagick \
     && ./download_chromedriver.sh \
@@ -70,8 +70,13 @@ ARG LIBRE_OFFICE_INSTALLATION_FILE_NAME=LibreOffice_${LIBRE_OFFICE_FULL_VERSION}
 # lines 8-10 is the configuration for sklearn
 # linex 11-14 - install LibreOffice for the office-utils image
 # lines 16-18 - enable more hashing alrogithms such as md4 for example for py3ews
+<<<<<<< HEAD
+RUN dnf install -y --nodocs python3-devel gcc gcc-c++ make wget git poppler poppler-utils iproute \
+        rust cargo libxml2-devel libxslt-devel \
+=======
 RUN dnf install -y --nodocs --enablerepo=$ROCKY_RELEASE python3-devel gcc gcc-c++ make wget git poppler poppler-utils \
         rust-1.62.1-1.el9.x86_64 cargo libxml2-devel libxslt-devel \
+>>>>>>> 027e08a3777910366f08c0d77432a766947348ef
         libffi-devel openssl-devel libffi libSM mesa-libGL \
         openssh ca-certificates openssl less rsync libpng-devel freetype-devel gcc-gfortran openblas unzip libstdc++ \
         && dnf install -y --nodocs --enablerepo=$FEDORA_EPEL p7zip unrar \

--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -34,7 +34,7 @@ RUN dnf update --nodocs -y  \
     && rm -rf chromedriver_linux64.zip \
     && google-chrome --version \
     && chromedriver --version \
-    && dnf install -y --enablerepo=$ROCKY_DEVEL --enablerepo=$ROCKY_BASE --nodocs git automake make autoconf libtool clang zlib zlib-devel libjpeg libjpeg-devel libwebp libwebp-devel \
+    && dnf install -y --enablerepo=$ROCKY_DEVEL --enablerepo=$ROCKY_BASE --nodocs git automake make autoconf libtool zlib clang-14.0.6-4.el9_1.x86_64 zlib-devel libjpeg libjpeg-devel libwebp libwebp-devel \
     libtiff libtiff-devel libpng libpng-devel pango giflib giflib-devel dejavu-sans-mono-fonts \
     && git clone --depth 1 -b $LEPTONICA_VERSION https://github.com/DanBloomberg/leptonica \
     && cd leptonica \
@@ -70,8 +70,8 @@ ARG LIBRE_OFFICE_INSTALLATION_FILE_NAME=LibreOffice_${LIBRE_OFFICE_FULL_VERSION}
 # lines 8-10 is the configuration for sklearn
 # linex 11-14 - install LibreOffice for the office-utils image
 # lines 16-18 - enable more hashing alrogithms such as md4 for example for py3ews
-RUN dnf install -y --nodocs python3-devel gcc gcc-c++ make wget git poppler poppler-utils \
-        rust cargo libxml2-devel libxslt-devel \
+RUN dnf install -y --nodocs --enablerepo=$ROCKY_RELEASE python3-devel gcc gcc-c++ make wget git poppler poppler-utils \
+        rust-1.62.1-1.el9.x86_64 cargo libxml2-devel libxslt-devel \
         libffi-devel openssl-devel libffi libSM mesa-libGL \
         openssh ca-certificates openssl less rsync libpng-devel freetype-devel gcc-gfortran openblas unzip libstdc++ \
         && dnf install -y --nodocs --enablerepo=$FEDORA_EPEL p7zip unrar \

--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -17,7 +17,7 @@ ARG FEDORA_EPEL=fedora-epel
 # there is not linux_signing_key.pub from google that is not based on sha1
 RUN dnf update --nodocs -y  \
     && dnf upgrade -y --nodocs \
-    && dnf install --nodocs -y wget git \
+    && dnf install --nodocs -y wget git iproute \
     && wget https://dl-ssl.google.com/linux/linux_signing_key.pub \
     && update-crypto-policies --set DEFAULT:SHA1 \
     && rpm --import linux_signing_key.pub \

--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -34,7 +34,7 @@ RUN dnf update --nodocs -y  \
     && rm -rf chromedriver_linux64.zip \
     && google-chrome --version \
     && chromedriver --version \
-    && dnf install -y --enablerepo=$ROCKY_DEVEL --enablerepo=$ROCKY_BASE --nodocs git automake make autoconf libtool zlib clang-14.0.6-4.el9_1.x86_64 zlib-devel libjpeg libjpeg-devel libwebp libwebp-devel \
+    && dnf install -y --enablerepo=$ROCKY_DEVEL --enablerepo=$ROCKY_BASE --nodocs git automake make autoconf libtool clang zlib zlib-devel libjpeg libjpeg-devel libwebp libwebp-devel \
     libtiff libtiff-devel libpng libpng-devel pango giflib giflib-devel dejavu-sans-mono-fonts \
     && git clone --depth 1 -b $LEPTONICA_VERSION https://github.com/DanBloomberg/leptonica \
     && cd leptonica \

--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -17,7 +17,7 @@ ARG FEDORA_EPEL=fedora-epel
 # there is not linux_signing_key.pub from google that is not based on sha1
 RUN dnf update --nodocs -y  \
     && dnf upgrade -y --nodocs \
-    && dnf install --nodocs -y wget git iproute \
+    && dnf install --nodocs -y wget git \
     && wget https://dl-ssl.google.com/linux/linux_signing_key.pub \
     && update-crypto-policies --set DEFAULT:SHA1 \
     && rpm --import linux_signing_key.pub \
@@ -70,7 +70,7 @@ ARG LIBRE_OFFICE_INSTALLATION_FILE_NAME=LibreOffice_${LIBRE_OFFICE_FULL_VERSION}
 # lines 8-10 is the configuration for sklearn
 # linex 11-14 - install LibreOffice for the office-utils image
 # lines 16-18 - enable more hashing alrogithms such as md4 for example for py3ews
-RUN dnf install -y --nodocs python3-devel gcc gcc-c++ make wget git poppler poppler-utils \
+RUN dnf install -y --nodocs python3-devel gcc gcc-c++ make wget git poppler poppler-utils iproute \
         rust cargo libxml2-devel libxslt-devel \
         libffi-devel openssl-devel libffi libSM mesa-libGL \
         openssh ca-certificates openssl less rsync libpng-devel freetype-devel gcc-gfortran openblas unzip libstdc++ \

--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -70,13 +70,8 @@ ARG LIBRE_OFFICE_INSTALLATION_FILE_NAME=LibreOffice_${LIBRE_OFFICE_FULL_VERSION}
 # lines 8-10 is the configuration for sklearn
 # linex 11-14 - install LibreOffice for the office-utils image
 # lines 16-18 - enable more hashing alrogithms such as md4 for example for py3ews
-<<<<<<< HEAD
-RUN dnf install -y --nodocs python3-devel gcc gcc-c++ make wget git poppler poppler-utils iproute \
+RUN dnf install -y --nodocs python3-devel gcc gcc-c++ make wget git poppler poppler-utils \
         rust cargo libxml2-devel libxslt-devel \
-=======
-RUN dnf install -y --nodocs --enablerepo=$ROCKY_RELEASE python3-devel gcc gcc-c++ make wget git poppler poppler-utils \
-        rust-1.62.1-1.el9.x86_64 cargo libxml2-devel libxslt-devel \
->>>>>>> 027e08a3777910366f08c0d77432a766947348ef
         libffi-devel openssl-devel libffi libSM mesa-libGL \
         openssh ca-certificates openssl less rsync libpng-devel freetype-devel gcc-gfortran openblas unzip libstdc++ \
         && dnf install -y --nodocs --enablerepo=$FEDORA_EPEL p7zip unrar \

--- a/docker/py3-native/verify.py
+++ b/docker/py3-native/verify.py
@@ -1,4 +1,9 @@
+
 # make sure regex is working cause in new versions there are problems
 import regex
 pattern = regex.Regex('\\\\d\\+', flags=regex.V0)
 print('regex is good')
+
+# make sure that the iproute command is installed in py3-native image
+import subprocess
+subprocess.check_output(["ip", "route", "list"], text=True, stderr=subprocess.STDOUT)


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5248)

## Description
Add the *iproute* command to add support for the **DockerHardeningCheck** script.


lint works now with this updated image on the **DockerHardeningCheck** script.
<img width="1725" alt="image" src="https://github.com/demisto/dockerfiles/assets/53861351/8d341de7-8dfd-4c82-87db-9f9f715c4313">
