### PR TITLE
[py3-native] - remove unlocks of clang and rust

### DIFF
--- a/docker/py3-native/CHANGELOG.md
+++ b/docker/py3-native/CHANGELOG.md
@@ -1,8 +1,6 @@
 # py3-native Changelog
 
 ## Unreleased
-* Locked the installation of the *clang* package to version 14 due to dependency conflicts with the *tigervnc-server-minimal* package.
-* Locked the installation of the *rust* package to version 1.62 due to dependency conflicts with the *tigervnc-server-minimal* package.
 * Updated the *LibreOffice* to the following version: **7.5.3**
 * Added the *iproute* library to allow support for the **DockerHardeningCheck** script.
 

--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -34,7 +34,7 @@ RUN dnf update --nodocs -y  \
     && rm -rf chromedriver_linux64.zip \
     && google-chrome --version \
     && chromedriver --version \
-    && dnf install -y --enablerepo=$ROCKY_DEVEL --enablerepo=$ROCKY_BASE --nodocs git automake make autoconf libtool zlib clang-14.0.6-4.el9_1.x86_64 zlib-devel libjpeg libjpeg-devel libwebp libwebp-devel \
+    && dnf install -y --enablerepo=$ROCKY_DEVEL --enablerepo=$ROCKY_BASE --nodocs git automake make autoconf libtool zlib clang zlib-devel libjpeg libjpeg-devel libwebp libwebp-devel \
     libtiff libtiff-devel libpng libpng-devel pango giflib giflib-devel dejavu-sans-mono-fonts \
     && git clone --depth 1 -b $LEPTONICA_VERSION https://github.com/DanBloomberg/leptonica \
     && cd leptonica \
@@ -71,7 +71,7 @@ ARG LIBRE_OFFICE_INSTALLATION_FILE_NAME=LibreOffice_${LIBRE_OFFICE_FULL_VERSION}
 # linex 11-14 - install LibreOffice for the office-utils image
 # lines 16-18 - enable more hashing alrogithms such as md4 for example for py3ews
 RUN dnf install -y --nodocs --enablerepo=$ROCKY_RELEASE python3-devel gcc gcc-c++ make wget git poppler poppler-utils \
-        rust-1.62.1-1.el9.x86_64 cargo libxml2-devel libxslt-devel \
+        rust cargo libxml2-devel libxslt-devel \
         libffi-devel openssl-devel libffi libSM mesa-libGL \
         openssh ca-certificates openssl less rsync libpng-devel freetype-devel gcc-gfortran openblas unzip libstdc++ \
         && dnf install -y --nodocs --enablerepo=$FEDORA_EPEL p7zip unrar \


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6599)

## Description
remove unlocks of clang and rust for the py3-native image as those packages were updated.