### PR TITLE
[py3-native] - update libreoffice to 7.5.4

### DIFF
--- a/docker/py3-native/CHANGELOG.md
+++ b/docker/py3-native/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Updated py3-native to be based on ubi-9.2.
+* Updated the *LibreOffice* to the following version: **7.5.4**
 
 ## 8.3.0
 * Updated the *LibreOffice* to the following version: **7.5.3**

--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -58,7 +58,7 @@ RUN dnf update --nodocs -y  \
     && rm -rf /var/cache/dnf
 
 ARG LIBRE_OFFICE_MAJOR_VERSION=7.5
-ARG LIBRE_OFFICE_FULL_VERSION=${LIBRE_OFFICE_MAJOR_VERSION}.3
+ARG LIBRE_OFFICE_FULL_VERSION=${LIBRE_OFFICE_MAJOR_VERSION}.4
 ARG LIBRE_OFFICE_INSTALLATION_FILE_NAME=LibreOffice_${LIBRE_OFFICE_FULL_VERSION}_Linux_x86-64_rpm
 # libre-office mirrors are taken from here - http://download.documentfoundation.org/libreoffice/stable/
 


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-7021)

## Description
update libreoffice to 7.5.4 as the mirror for update libreoffice to 7.5.3 is broken
