### PR TITLE
[python3-ubi] - convert to ubi 9.2 minimal

### DIFF
--- a/docker/python3-ubi/Dockerfile
+++ b/docker/python3-ubi/Dockerfile
@@ -95,7 +95,7 @@ Options = UnsafeLegacyRenegotiation\n' > /tmp/ssl.cnf \
     && grep -C 10 'Options = UnsafeLegacyRenegotiation' /etc/pki/tls/openssl.cnf
 
 RUN microdnf update -y --nodocs && \
-    microdnf install -y --nodocs shadow-utils && \
+    microdnf install -y --nodocs shadow-utils which && \
     groupadd -g 4000 demisto && \
     useradd -u 4000 -g demisto demisto -s /bin/sh
 

--- a/docker/python3-ubi/Dockerfile
+++ b/docker/python3-ubi/Dockerfile
@@ -1,10 +1,12 @@
-ARG BASE_UBI_TAG=9.2
+ARG BASE_UBI_TAG=ubi-minimal:9.2
 ARG BASE_UBI_VERSION=ubi9
 
 FROM registry.access.redhat.com/${BASE_UBI_VERSION}:${BASE_UBI_TAG} as build
 
-RUN dnf upgrade -y --nodocs && \
-    dnf install -y --nodocs \
+RUN microdnf upgrade -y --nodocs && \
+    microdnf install -y --nodocs \
+       tar \
+       findutils \
        bzip2-devel \
        expat-devel \
        gcc \
@@ -16,8 +18,8 @@ RUN dnf upgrade -y --nodocs && \
        wget \
        zlib-devel \
        xz-devel && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+    microdnf clean all && \
+    rm -rf /var/cache/microdnf
 
 # install python3
 RUN wget https://www.python.org/ftp/python/3.10.8/Python-3.10.8.tgz && \
@@ -49,10 +51,10 @@ RUN pip3.10 install -r requirements.txt
 
 FROM registry.access.redhat.com/${BASE_UBI_VERSION}:${BASE_UBI_TAG}
 
-RUN dnf update -y --nodocs && \
-    dnf install -y --nodocs procps-ng && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+RUN microdnf update -y --nodocs && \
+    microdnf install -y --nodocs procps-ng && \
+    microdnf clean all && \
+    rm -rf /var/cache/microdnf
 
 ENV PATH /usr/local/bin:/home/python/.local/bin:$PATH
 

--- a/docker/python3-ubi/Dockerfile
+++ b/docker/python3-ubi/Dockerfile
@@ -98,7 +98,7 @@ RUN microdnf update -y --nodocs && \
     microdnf install -y --nodocs shadow-utils which expat && \
     groupadd -g 4000 demisto && \
     useradd -u 4000 -g demisto demisto -s /bin/sh && \
-    microdnf remove -y shadow-utils expat && \
+    microdnf remove -y shadow-utils && \
     microdnf -y clean all && \
     rm -rf /var/cache
 

--- a/docker/python3-ubi/Dockerfile
+++ b/docker/python3-ubi/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf upgrade -y --nodocs && \
        zlib-devel \
        xz-devel && \
     microdnf clean all && \
-    rm -rf /var/cache/microdnf
+    rm -rf /var/cache
 
 # install python3
 RUN wget https://www.python.org/ftp/python/3.10.8/Python-3.10.8.tgz && \
@@ -54,7 +54,7 @@ FROM registry.access.redhat.com/${BASE_UBI_VERSION}/${BASE_UBI_TAG}
 RUN microdnf update -y --nodocs && \
     microdnf install -y --nodocs procps-ng && \
     microdnf clean all && \
-    rm -rf /var/cache/microdnf
+    rm -rf /var/cache
 
 ENV PATH /usr/local/bin:/home/python/.local/bin:$PATH
 
@@ -97,7 +97,10 @@ Options = UnsafeLegacyRenegotiation\n' > /tmp/ssl.cnf \
 RUN microdnf update -y --nodocs && \
     microdnf install -y --nodocs shadow-utils which expat && \
     groupadd -g 4000 demisto && \
-    useradd -u 4000 -g demisto demisto -s /bin/sh
+    useradd -u 4000 -g demisto demisto -s /bin/sh && \
+    microdnf remove -y shadow-utils which expat && \
+    microdnf -y clean all && \
+    rm -rf /var/cache
 
 CMD ["python3"]
 

--- a/docker/python3-ubi/Dockerfile
+++ b/docker/python3-ubi/Dockerfile
@@ -95,7 +95,7 @@ Options = UnsafeLegacyRenegotiation\n' > /tmp/ssl.cnf \
     && grep -C 10 'Options = UnsafeLegacyRenegotiation' /etc/pki/tls/openssl.cnf
 
 RUN microdnf update -y --nodocs && \
-    microdnf install -y --nodocs shadow-utils which && \
+    microdnf install -y --nodocs shadow-utils which expat && \
     groupadd -g 4000 demisto && \
     useradd -u 4000 -g demisto demisto -s /bin/sh
 

--- a/docker/python3-ubi/Dockerfile
+++ b/docker/python3-ubi/Dockerfile
@@ -6,7 +6,6 @@ FROM registry.access.redhat.com/${BASE_UBI_VERSION}/${BASE_UBI_TAG} as build
 RUN microdnf upgrade -y --nodocs && \
     microdnf install -y --nodocs \
        tar \
-       shadow-utils \
        findutils \
        bzip2-devel \
        expat-devel \
@@ -95,7 +94,9 @@ Options = UnsafeLegacyRenegotiation\n' > /tmp/ssl.cnf \
     && rm /tmp/ssl.cnf \
     && grep -C 10 'Options = UnsafeLegacyRenegotiation' /etc/pki/tls/openssl.cnf
 
-RUN groupadd -g 4000 demisto && \
+RUN microdnf update -y --nodocs && \
+    microdnf install -y --nodocs shadow-utils && \
+    groupadd -g 4000 demisto && \
     useradd -u 4000 -g demisto demisto -s /bin/sh
 
 CMD ["python3"]

--- a/docker/python3-ubi/Dockerfile
+++ b/docker/python3-ubi/Dockerfile
@@ -6,6 +6,7 @@ FROM registry.access.redhat.com/${BASE_UBI_VERSION}/${BASE_UBI_TAG} as build
 RUN microdnf upgrade -y --nodocs && \
     microdnf install -y --nodocs \
        tar \
+       shadow-utils \
        findutils \
        bzip2-devel \
        expat-devel \

--- a/docker/python3-ubi/Dockerfile
+++ b/docker/python3-ubi/Dockerfile
@@ -98,7 +98,7 @@ RUN microdnf update -y --nodocs && \
     microdnf install -y --nodocs shadow-utils which expat && \
     groupadd -g 4000 demisto && \
     useradd -u 4000 -g demisto demisto -s /bin/sh && \
-    microdnf remove -y shadow-utils which expat && \
+    microdnf remove -y shadow-utils expat && \
     microdnf -y clean all && \
     rm -rf /var/cache
 

--- a/docker/python3-ubi/Dockerfile
+++ b/docker/python3-ubi/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_UBI_TAG=ubi-minimal:9.2
 ARG BASE_UBI_VERSION=ubi9
 
-FROM registry.access.redhat.com/${BASE_UBI_VERSION}:${BASE_UBI_TAG} as build
+FROM registry.access.redhat.com/${BASE_UBI_VERSION}/${BASE_UBI_TAG} as build
 
 RUN microdnf upgrade -y --nodocs && \
     microdnf install -y --nodocs \
@@ -49,7 +49,7 @@ RUN find /usr/local -depth \
 COPY requirements.txt .
 RUN pip3.10 install -r requirements.txt
 
-FROM registry.access.redhat.com/${BASE_UBI_VERSION}:${BASE_UBI_TAG}
+FROM registry.access.redhat.com/${BASE_UBI_VERSION}/${BASE_UBI_TAG}
 
 RUN microdnf update -y --nodocs && \
     microdnf install -y --nodocs procps-ng && \


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6831)

## Description
Change python3-ubi image from ubi 9.2 to ubi 9.2 minimal image.