### PR TITLE
[py3-tools-ubi] - ubi 9.2 minimal

### DIFF
--- a/docker/py3-tools-ubi/Dockerfile
+++ b/docker/py3-tools-ubi/Dockerfile
@@ -1,8 +1,8 @@
-FROM demisto/python3-ubi:3.10.8.62292
+FROM devdemisto/python3-ubi:3.10.8.64170
 
 COPY requirements.txt .
 
-RUN dnf install -y --nodocs python3-devel gcc gcc-c++ make wget git && \
+RUN microdnf install -y --nodocs python3-devel gcc gcc-c++ make wget git && \
         pip install --no-cache-dir -r requirements.txt && \
         dnf remove -y python3-devel gcc gcc-c++ make wget git platform-python-pip && \
         dnf clean all && \

--- a/docker/py3-tools-ubi/Dockerfile
+++ b/docker/py3-tools-ubi/Dockerfile
@@ -4,7 +4,7 @@ COPY requirements.txt .
 
 RUN microdnf install -y --nodocs python3-devel gcc gcc-c++ make wget git && \
         pip install --no-cache-dir -r requirements.txt && \
-        dnf remove -y python3-devel gcc gcc-c++ make wget git platform-python-pip && \
-        dnf clean all && \
-        rm -rf /var/cache/dnf
+        microdnf remove -y python3-devel gcc gcc-c++ make wget git platform-python-pip && \
+        microdnf clean all && \
+        rm -rf /var/cache/microdnf
 

--- a/docker/py3-tools-ubi/Dockerfile
+++ b/docker/py3-tools-ubi/Dockerfile
@@ -4,7 +4,7 @@ COPY requirements.txt .
 
 RUN microdnf install -y --nodocs python3-devel gcc gcc-c++ make wget git && \
         pip install --no-cache-dir -r requirements.txt && \
-        microdnf remove -y python3-devel gcc gcc-c++ make wget platform-python-pip git && \
+        microdnf remove -y python3-devel gcc gcc-c++ make wget platform-python-pip git perl-Git && \
         microdnf clean all && \
         rm -rf /var/cache
 

--- a/docker/py3-tools-ubi/Dockerfile
+++ b/docker/py3-tools-ubi/Dockerfile
@@ -1,10 +1,10 @@
-FROM devdemisto/python3-ubi:3.10.8.64170
+FROM devdemisto/python3-ubi:3.10.8.65160
 
 COPY requirements.txt .
 
 RUN microdnf install -y --nodocs python3-devel gcc gcc-c++ make wget git && \
         pip install --no-cache-dir -r requirements.txt && \
-        microdnf remove -y python3-devel gcc gcc-c++ make wget platform-python-pip && \
+        microdnf remove -y python3-devel gcc gcc-c++ make wget platform-python-pip git && \
         microdnf clean all && \
-        rm -rf /var/cache/microdnf
+        rm -rf /var/cache
 

--- a/docker/py3-tools-ubi/Dockerfile
+++ b/docker/py3-tools-ubi/Dockerfile
@@ -4,7 +4,7 @@ COPY requirements.txt .
 
 RUN microdnf install -y --nodocs python3-devel gcc gcc-c++ make wget git && \
         pip install --no-cache-dir -r requirements.txt && \
-        microdnf remove -y python3-devel gcc gcc-c++ make wget git platform-python-pip && \
+        microdnf remove -y python3-devel gcc gcc-c++ make wget platform-python-pip && \
         microdnf clean all && \
         rm -rf /var/cache/microdnf
 


### PR DESCRIPTION

## Status
Ready

## Related Issues
Related: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6831)

## Description
make py3-tools-ubi to ubi 9.2 minimal.