### PR TITLE
Fix for trust push failures

### DIFF
--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -103,7 +103,9 @@ function commit_dockerfiles_trust {
     if [[ $(git status --short) ]]; then
         echo "dockerfiles-trust: found modified/new files to commit"
         git status --short
-        git pull
+        git stash
+        git pull --no-rebase
+        git checkout stash -- .
         echo "starting commit loop..."
         git add .
         git commit -m "`date`: trust update from PR: ${CIRCLE_PULL_REQUEST}"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
Related: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5352)

[PR](https://app.circleci.com/pipelines/github/demisto/dockerfiles/58151/workflows/6c2397c8-48ca-4e61-8573-4dff03264cbb/jobs/64256) of regular build still working okay 

## Description
The Problem in the issue is a result of a race condition between the cloning of the dockerfiles-trust repo and pulling to update from it. If it was updated, the pull will fail. Stashing changes and checking them out again after the pull is a solution to the problem.

## Screenshots of checking git commands work as expected
![image](https://github.com/demisto/dockerfiles/assets/72339665/16cffebd-95cc-4e2a-a86d-98568060a2e3)

![image](https://github.com/demisto/dockerfiles/assets/72339665/d84fae8f-3099-4b79-aed0-d812bc9e15de)

