### PR TITLE
snap7 fix

### DIFF
--- a/docker/panw-iot/Dockerfile
+++ b/docker/panw-iot/Dockerfile
@@ -1,9 +1,14 @@
 # Part of IOT - XSOAR integration project. 
 # See docs at: https://docs.paloaltonetworks.com/iot/iot-security-integration/get-started-with-iot-security-integrations/third-party-integrations-using-on-premises-xsoar#id99b6436d-38d5-464d-9f8f-87bc84d6b628
-FROM demisto/python3:3.10.12.65389
+FROM demisto/python3-deb:3.10.12.65454
 
 COPY requirements.txt .
 
-RUN apk --update add --no-cache --virtual .build-dependencies python3-dev build-base wget git \
+RUN apt-get update && apt-get install -y --no-install-recommends python3-dev wget git \
   && pip install --no-cache-dir -r requirements.txt \
-  && apk del .build-dependencies
+  && apt-get purge -y --auto-remove \
+  gcc \
+  python3-dev \
+  wget \
+  git \
+&& rm -rf /var/lib/apt/lists/*

--- a/docker/panw-iot/Pipfile.lock
+++ b/docker/panw-iot/Pipfile.lock
@@ -240,11 +240,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1",
-                "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"
+                "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11",
+                "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.3"
+            "version": "==2.0.4"
         },
         "websocket-client": {
             "hashes": [

--- a/docker/panw-iot/verify.py
+++ b/docker/panw-iot/verify.py
@@ -5,4 +5,6 @@ import websocket as wsc
 from websocket import WebSocketApp
 import snap7
 
+snap7client = snap7.client.Client()
+
 print("All is good. PANW IoT python packages imported successfully!")


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/In Progress/In Hold (Reason for hold)

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: link to the issue

## Description
After adding "snap7client = snap7.client.Client()" in verify.py we see the following error: 
`raise RuntimeError("can't find snap7 library. If installed, try running ldconfig")`
Changed to "python3-deb" and it resolved the issue. 
