### PR TITLE
lock pycti to 5.9.6

### DIFF
--- a/docker/vendors-sdk/poetry.lock
+++ b/docker/vendors-sdk/poetry.lock
@@ -477,13 +477,13 @@ files = [
 
 [[package]]
 name = "pycti"
-version = "5.10.1"
+version = "5.9.6"
 description = "Python API client for OpenCTI."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pycti-5.10.1-py3-none-any.whl", hash = "sha256:ea5c510e1d1460fb81ec4545631817ba1ae4e2d080ed216d1987061325ce82dd"},
-    {file = "pycti-5.10.1.tar.gz", hash = "sha256:797912a2dcb2554219b9101c82f0abdfb2626215bd1db87b8b279fb34807b670"},
+    {file = "pycti-5.9.6-py3-none-any.whl", hash = "sha256:88b1db386f7129ed2a5dc73116e5075cd40de2dc8caa7bb04ba87f40b82473fc"},
+    {file = "pycti-5.9.6.tar.gz", hash = "sha256:6564a4fd7414b2f1ac5c049a63816d1fdbb66a48fdf9971735c611dd3108e89f"},
 ]
 
 [package.dependencies]
@@ -496,12 +496,12 @@ python-magic = {version = ">=0.4.27,<0.5.0", markers = "sys_platform == \"linux\
 python-magic-bin = {version = ">=0.4.14,<0.5.0", markers = "sys_platform == \"win32\""}
 pyyaml = ">=6.0,<7.0"
 requests = ">=2.31.0,<2.32.0"
-setuptools = ">=68.1.0,<68.2.0"
+setuptools = ">=68.0.0,<68.1.0"
 stix2 = ">=3.0.1,<3.1.0"
 
 [package.extras]
-dev = ["black (>=23.7.0,<23.8.0)", "build (>=0.10.0,<0.11.0)", "isort (>=5.12.0,<5.13.0)", "pre-commit (>=3.3.2,<3.4.0)", "pytest (>=7.4.0,<7.5.0)", "pytest-cases (>=3.6.13,<3.7.0)", "pytest-cov (>=4.1.0,<4.2.0)", "pytest-randomly (>=3.15.0,<3.16.0)", "types-python-dateutil (>=2.8.19,<2.9.0)", "types-pytz (>=2023.3.0.0,<2023.4.0.0)", "wheel (>=0.41.0,<0.42.0)"]
-doc = ["autoapi (>=2.0.1,<2.1.0)", "sphinx-autodoc-typehints (>=1.24.0,<1.25.0)", "sphinx-rtd-theme (>=1.3.0,<1.4.0)"]
+dev = ["black (>=23.7.0,<23.8.0)", "build (>=0.10.0,<0.11.0)", "isort (>=5.12.0,<5.13.0)", "pre-commit (>=3.3.2,<3.4.0)", "pytest (>=7.4.0,<7.5.0)", "pytest-cases (>=3.6.13,<3.7.0)", "pytest-cov (>=4.1.0,<4.2.0)", "pytest-randomly (>=3.13.0,<3.14.0)", "types-python-dateutil (>=2.8.19,<2.9.0)", "types-pytz (>=2023.3.0.0,<2023.4.0.0)", "wheel (>=0.40.0,<0.41.0)"]
+doc = ["autoapi (>=2.0.1,<2.1.0)", "sphinx-autodoc-typehints (>=1.23.0,<1.24.0)", "sphinx-rtd-theme (>=1.2.1,<1.3.0)"]
 
 [[package]]
 name = "pydantic"
@@ -920,18 +920,18 @@ dev = ["black (>=22.3.0)", "build (>=0.7.0)", "isort (>=5.11.4)", "pyflakes (>=2
 
 [[package]]
 name = "setuptools"
-version = "68.1.2"
+version = "68.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "setuptools-68.1.2-py3-none-any.whl", hash = "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"},
-    {file = "setuptools-68.1.2.tar.gz", hash = "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d"},
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5,<=7.1.2)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -1150,4 +1150,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10"
-content-hash = "b926986331f55a89bdf1baa7760509614396478f783a34c2a6a26fb5b32dfe8d"
+content-hash = "ea084cac13c6b94425335ec3b87d410b3c60bb737bfa1242db9b7f092d28bc01"

--- a/docker/vendors-sdk/pyproject.toml
+++ b/docker/vendors-sdk/pyproject.toml
@@ -12,7 +12,7 @@ confluent-kafka = "==1.7.0" # https://github.com/confluentinc/confluent-kafka-py
 fp-ngfw-smc-python = "*"
 pydantic = "*"
 duo-client = "*"
-pycti = "==5.9.6"
+pycti = "==5.9.6" # bug when using the version 5.10.1
 pyhcl = "*"
 cymruwhois = "*"
 jbxapi = "*"

--- a/docker/vendors-sdk/pyproject.toml
+++ b/docker/vendors-sdk/pyproject.toml
@@ -12,7 +12,7 @@ confluent-kafka = "==1.7.0" # https://github.com/confluentinc/confluent-kafka-py
 fp-ngfw-smc-python = "*"
 pydantic = "*"
 duo-client = "*"
-pycti = "*"
+pycti = "==5.9.6"
 pyhcl = "*"
 cymruwhois = "*"
 jbxapi = "*"

--- a/docker/vendors-sdk/pyproject.toml
+++ b/docker/vendors-sdk/pyproject.toml
@@ -12,7 +12,7 @@ confluent-kafka = "==1.7.0" # https://github.com/confluentinc/confluent-kafka-py
 fp-ngfw-smc-python = "*"
 pydantic = "*"
 duo-client = "*"
-pycti = "==5.9.6" # bug when using the version 5.10.1
+pycti = "==5.9.6" # bug when using the version 5.10.1 see CIAC-8395
 pyhcl = "*"
 cymruwhois = "*"
 jbxapi = "*"


### PR DESCRIPTION

## Related Content Pull Request
Related PR: https://github.com/demisto/content/pull/29575

## Related Issues
Related: https://jira-hq.paloaltonetworks.local/browse/CIAC-861

## Description
lock `pycti` to version 5.9.6 (the last version used before the new `versions-sdk` image) due to an error in the version `5.10.1`

<img width="1133" alt="image" src="https://github.com/demisto/dockerfiles/assets/79846863/5998938e-4f64-4877-a60f-f4101f65c905">
