### PR TITLE
vendors-sdk: update lock reason

### DIFF
--- a/docker/vendors-sdk/pyproject.toml
+++ b/docker/vendors-sdk/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "~3.10"
 cloakensdk = "*"
-confluent-kafka = "==1.7.0" # https://github.com/confluentinc/confluent-kafka-python/issues/180
+confluent-kafka = "==1.7.0" # need specific version of os package, see CIAC-8412
 fp-ngfw-smc-python = "*"
 pydantic = "*"
 duo-client = "*"


### PR DESCRIPTION


## Related Issues
Related: https://jira-hq.paloaltonetworks.local/browse/CIAC-861
https://jira-hq.paloaltonetworks.local/browse/CIAC-8412


## Description
create jira ticket and update the toml file for future try to release the version lock.