### PR TITLE
Add packages for mypy_boto3

### DIFF
--- a/docker/boto3py3/Pipfile
+++ b/docker/boto3py3/Pipfile
@@ -7,6 +7,9 @@ verify_ssl = true
 
 [packages]
 boto3 = "*"
+mypy_boto3_guardduty = "*"
+mypy_boto3_securityhub = "*"
+mypy_boto3_waf = "*"
 
 [requires]
 python_version = "3.10"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Content Pull Request
Related PR: [link to the PR at demisto/content](https://github.com/demisto/content/pull/29819)

## Related Issues
Related: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-8236)

## Description
To avoid the `MyPy` errors that `"boto3.client" is not valid as a type`, it is necessary to use `mypy_boto3` for the types.