### PR TITLE
undeprecate python image

### DIFF
--- a/docker/deprecated_images.json
+++ b/docker/deprecated_images.json
@@ -180,11 +180,6 @@
         "created_time_utc": "2023-10-10T12:09:59.767889Z"
     },
     {
-        "image_name": "demisto/python",
-        "reason": "Python 2 is EOL. Use the python3 image instead.",
-        "created_time_utc": "2023-10-10T12:09:59.767889Z"
-    },
-    {
         "image_name": "demisto/splunksdk",
         "reason": "Python 2 is EOL. Use the python3 image instead.",
         "created_time_utc": "2023-10-10T12:09:59.767889Z"


### PR DESCRIPTION
python image is used by `CommonServerPython` and it can't be deprecated yet.

We can deprecate it again when we update the demisto-sdk and content to ignore this error on `CommonServerPython`

PR in content which fails on this validation: https://github.com/demisto/content/pull/30300
