### PR TITLE
Mark the image python_pancloud_v2 as not deprecated

### DIFF
--- a/docker/deprecated_images.json
+++ b/docker/deprecated_images.json
@@ -320,11 +320,6 @@
         "reason": "Image not in use by non-deprecated content item."
     },
     {
-        "created_time_utc": "2024-01-02 17:03:39.493485",
-        "image_name": "demisto/python_pancloud_v2",
-        "reason": "Image not in use by non-deprecated content item."
-    },
-    {
         "created_time_utc": "2022-05-31T17:55:47.548487Z",
         "image_name": "demisto/python_zipfile",
         "reason": "Use the demisto/py3-tools docker image instead."

--- a/docker/python_pancloud_v2/build.conf
+++ b/docker/python_pancloud_v2/build.conf
@@ -1,3 +1,1 @@
 version=1.0.0
-deprecated=true
-deprecated_reason=Image not in use by non-deprecated content item.


### PR DESCRIPTION

## Related Issues
Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-9482

## Description
Mark the image `python_pancloud_v2` as not deprecated
as it used in `Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.yml`