### PR TITLE
Ignore scikit-learn For ml Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -339,6 +339,8 @@ updates:
     directory: /docker/ml
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: scikit-learn
   - package-ecosystem: pip
     directory: /docker/fastapi
     schedule:


### PR DESCRIPTION
## Status
Ready/In Progress/In Hold (Reason for hold)

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: link to the issue

## Description
Ignore the `scikit-learn` package when updating the `ml` docker image (previously it was ignored in `mlurlphishing` only).
