### PR TITLE
[demisto-sdk] - install newer node and validate mdx server works

### DIFF
--- a/docker/demisto-sdk/Dockerfile
+++ b/docker/demisto-sdk/Dockerfile
@@ -10,10 +10,8 @@ ADD requirements.txt .
 
 
 RUN apt-get update && apt-get -y --no-install-recommends upgrade && apt-get install \
-    git \ 
+    git \
     gcc \
-    nodejs \
-    npm \
     ca-certificates \
     curl \
     gnupg \
@@ -25,6 +23,10 @@ RUN apt-get update && apt-get -y --no-install-recommends upgrade && apt-get inst
     xz-utils tk-dev libffi-dev liblzma-dev zsh \
     libffi-dev python3-dev gfortran g++ pkg-config libhdf5-dev \
     -y \
+    # install node - node distributions: https://github.com/nodesource/distributions
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt update \
+    && apt-get install -y nodejs \
     # install docker
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \

--- a/docker/demisto-sdk/Dockerfile
+++ b/docker/demisto-sdk/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get -y --no-install-recommends upgrade && apt-get inst
     && apt-get update && apt-get install docker-ce-cli -y \
     && python3 -m pip install --no-cache-dir -r requirements.txt \
     && npm ci \
+    && npm install \
     && npm install -g jsdoc-to-markdown@5.0.3 \
     && demisto-sdk --version
 

--- a/docker/demisto-sdk/Dockerfile
+++ b/docker/demisto-sdk/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get update && apt-get -y --no-install-recommends upgrade && apt-get inst
     && apt-get update && apt-get install docker-ce-cli -y \
     && python3 -m pip install --no-cache-dir -r requirements.txt \
     && npm ci \
-    && npm install \
     && npm install -g jsdoc-to-markdown@5.0.3 \
+    && npm list \
     && demisto-sdk --version
 
 # Default demisto-sdk help

--- a/docker/demisto-sdk/verify.py
+++ b/docker/demisto-sdk/verify.py
@@ -1,5 +1,4 @@
-from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator
-from demisto_sdk.commands.common.hook_validations.readme import mdx_server_is_up
+from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator, mdx_server_is_up
 
 with ReadMeValidator.start_mdx_server():
     assert mdx_server_is_up()

--- a/docker/demisto-sdk/verify.py
+++ b/docker/demisto-sdk/verify.py
@@ -1,4 +1,7 @@
 from demisto_sdk.commands.common.MDXServer import start_local_MDX_server
+from demisto_sdk.commands.common.hook_validations.readme import mdx_server_is_up
 
 with start_local_MDX_server():
-    print("successfully started mdx server")
+    assert mdx_server_is_up()
+
+print("successfully started mdx server")

--- a/docker/demisto-sdk/verify.py
+++ b/docker/demisto-sdk/verify.py
@@ -1,7 +1,7 @@
-from demisto_sdk.commands.common.MDXServer import start_local_MDX_server
+from demisto_sdk.commands.common.hook_validations.readme import ReadMeValidator
 from demisto_sdk.commands.common.hook_validations.readme import mdx_server_is_up
 
-with start_local_MDX_server():
+with ReadMeValidator.start_mdx_server():
     assert mdx_server_is_up()
 
 print("successfully started mdx server")

--- a/docker/demisto-sdk/verify.py
+++ b/docker/demisto-sdk/verify.py
@@ -1,0 +1,4 @@
+from demisto_sdk.commands.common.MDXServer import start_local_MDX_server
+
+with start_local_MDX_server():
+    print("successfully started mdx server")


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-9916)
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-9356)

## Description
* The node version in the demisto-sdk installs very old node (12). The mdx server running validations on markdown files cannot run with such old node, upgrading the node to a version where the mdx server can run.

