### PR TITLE
Update `authutils` Dockerfile

### DIFF
--- a/docker/auth-utils/Dockerfile
+++ b/docker/auth-utils/Dockerfile
@@ -3,7 +3,7 @@ FROM demisto/crypto:1.0.0.89294
 
 COPY requirements.txt .
 
-RUN apk --update add --no-cache krb5 krb5-libs
+RUN apk --update add --no-cache krb5 krb5-libs openssl
 RUN apk --update add --no-cache --virtual .build-dependencies python3-dev libffi-dev gcc build-base wget git \
   openssl-dev krb5-dev \
   && pip install --no-cache-dir -r requirements.txt \


### PR DESCRIPTION

## Description
`authutils` replace the old image `ssl-analyze`
but the `openssl` is missed in `authutils`