### PR TITLE
locking gdetect version

### DIFF
--- a/docker/gdetect/Pipfile
+++ b/docker/gdetect/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-gdetect = "*"
+gdetect = "0.2.3"
 
 [dev-packages]
 

--- a/docker/gdetect/Pipfile
+++ b/docker/gdetect/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-gdetect = "0.2.3"
+gdetect = "0.2.0"
 
 [dev-packages]
 

--- a/docker/gdetect/Pipfile.lock
+++ b/docker/gdetect/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bc1f1886df6e1f9de8a04344e6b2185fdc91cddf6a335fce7a79b62ed8f165b2"
+            "sha256": "388f7ec41ff375eeff662d3525583e47d76336b7c1a7080ba30259a348f49358"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,19 +34,18 @@
         },
         "click": {
             "hashes": [
-                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
-                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+                "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
+                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==8.1.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.3"
         },
         "click-default-group": {
             "hashes": [
-                "sha256:9b60486923720e7fc61731bdb32b617039aba820e22e1c88766b1125592eaa5f",
-                "sha256:eb3f3c99ec0d456ca6cd2a7f08f7d4e91771bef51b01bdd9580cc6450fe1251e"
+                "sha256:d9560e8e8dfa44b3562fbc9425042a0fd6d21956fcc2db0077f63f34253ab904"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==1.2.4"
+            "version": "==1.2.2"
         },
         "colorama": {
             "hashes": [
@@ -65,12 +64,12 @@
         },
         "gdetect": {
             "hashes": [
-                "sha256:19e04f320b06085ab1cd0f2b676cf17e6932d34c42bfce67c175ee45ce45ed1a",
-                "sha256:cb589e1094e9806ccd6fb84b27c96e5dd94589c350c7004b209b213965179c33"
+                "sha256:200217ff8085ddd8e88c2c739927152241862e508d1e4d12ce837e6d08e4027f",
+                "sha256:f3b4c6adb82107acb02f77ed05a41f9bc608f3fd286a6e589ec2a074b1676aed"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==0.5.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.2.3"
         },
         "idna": {
             "hashes": [
@@ -98,11 +97,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:1a6266a5738115017bb64a66c59c717e7aa047b3ae49a011ede4abdeffc6536e",
-                "sha256:d5f49ad91fb343efcae45a2b2df04a9755e863e50413623ab8c9e74f05aee52b"
+                "sha256:c32a8340b21c75931f157466fefe81ae10b92c36a5ea34524dff3767238774a4",
+                "sha256:d7a8086aa1fa7e817e3bba544eee4fd82047ef59036313147759c11475f0dafd"
             ],
             "markers": "python_full_version >= '3.6.2' and python_full_version < '4.0.0'",
-            "version": "==11.2.0"
+            "version": "==11.0.0"
         },
         "urllib3": {
             "hashes": [

--- a/docker/gdetect/Pipfile.lock
+++ b/docker/gdetect/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "388f7ec41ff375eeff662d3525583e47d76336b7c1a7080ba30259a348f49358"
+            "sha256": "2d3d0a07d280287dac1f456229132c5ab8c0849adc1a6c7b3236bc71771fe66f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -64,12 +64,12 @@
         },
         "gdetect": {
             "hashes": [
-                "sha256:200217ff8085ddd8e88c2c739927152241862e508d1e4d12ce837e6d08e4027f",
-                "sha256:f3b4c6adb82107acb02f77ed05a41f9bc608f3fd286a6e589ec2a074b1676aed"
+                "sha256:5bb2df8303d906c98e719b1c80732a1c0f0d87144949473e350bd39dcd882b3d",
+                "sha256:8129b480e7740b48f5170a071da097945e4656a9ce183b783cd473bdedaa9f30"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==0.2.3"
+            "version": "==0.2.0"
         },
         "idna": {
             "hashes": [

--- a/docker/gdetect/verify.py
+++ b/docker/gdetect/verify.py
@@ -1,0 +1,3 @@
+import gdetect
+
+print("Successfully imported 'gdetect'")


### PR DESCRIPTION
## Status
Ready

## Related Content Pull Request
Related PR: [link to the PR at demisto/content](https://github.com/demisto/content/pull/33553)

## Description
locking gdetect version as integration code is not compatible with recent versions.

