### PR TITLE
[crypto] improve verify

### DIFF
--- a/docker/crypto/verify.py
+++ b/docker/crypto/verify.py
@@ -1,6 +1,7 @@
 from cryptography.fernet import Fernet
 import msal
-import OpenSSL.crypto
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.hazmat.primitives import serialization
 from bs4 import BeautifulSoup
 # Make sure cryptograph works
 key = Fernet.generate_key()


### PR DESCRIPTION
## Related Content Pull Request
Related PR: [link](https://github.com/demisto/content/pull/32858) to the PR at demisto/content

## Related Issues
Related: [link](https://jira-dc.paloaltonetworks.com/browse/CIAC-9119) to the issue

## Description
The verify file does not capture  the BC that PyOpenSSL does in version [23.3.0](https://www.pyopenssl.org/en/stable/changelog.html#id7)
