### PR TITLE
lock exchangelib to 5.2.0

### DIFF
--- a/docker/py3ews/Pipfile
+++ b/docker/py3ews/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-exchangelib = ">=5.2.0"
+exchangelib = "==5.2.0"
 
 chardet = "*"
 dateparser = "*"

--- a/docker/py3ews/Pipfile.lock
+++ b/docker/py3ews/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7ce569f717fe14e8fea596b69239f26d0d46c7b372b23675dd8716ce6c0fe2f8"
+            "sha256": "6d76c5fbf6a557fee32bf4f7021ed598d1bbae419cb48239dd9c5d9d266ff193"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -269,12 +269,12 @@
         },
         "exchangelib": {
             "hashes": [
-                "sha256:33e2c7bd45718d940ee9920479907f50d3bc6b8d496a78dbc87fca8f8ddcc189",
-                "sha256:e093fe18062992d8a78bbdcc2564ec5c92deb644e9f62ea710521a1dd8dfce76"
+                "sha256:01415aaaaeb7a254d6865ee10f966d3d9c4beb4c077f83417bd16b7a48c30068",
+                "sha256:c14403aa704230bafe570b7bbf21fc97228f382c16aef5230afef3df106d861c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==5.4.1"
+            "version": "==5.2.0"
         },
         "future": {
             "hashes": [


### PR DESCRIPTION
## Status
Ready

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: link to the issue

## Description
lock exchanglib to 5.2.0 since >5.2.0 breaks ews integration
