### PR TITLE
[py3-native Changelog] python 3.11

### DIFF
--- a/docker/py3-native/CHANGELOG.md
+++ b/docker/py3-native/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Updated the library ***exchangelib*** to version ***5.0.3*** to allow support for the **EWSv2**  intgration.
 * Added the library ***ntlm_auth*** to allow support for the **EWSv2**  intgration.
+* Updated the image to use Python 3.11.
 
 
 ## 8.6.0


### PR DESCRIPTION
## Related Issues
Related: [link](https://jira-dc.paloaltonetworks.com/browse/CIAC-5776) to the issue

## Description
Added to the 'py3-native' changelog file: In the upcoming version (8.7) of the native image (GA), the Python version will be updated to 3.11.