### PR TITLE
Deprecate nltk

### DIFF
--- a/docker/deprecated_images.json
+++ b/docker/deprecated_images.json
@@ -458,5 +458,10 @@
         "created_time_utc": "2024-01-02 17:03:39.499335",
         "image_name": "demisto/zeep",
         "reason": "Image no longer in use by content"
+    },
+    {
+        "image_name": "demisto/nltk",
+        "reason": "The image is used exclusively by the deprecated content script WordTokenizer.",
+        "created_time_utc": "2024-07-23T11:34:04.271203Z"
     }
 ]

--- a/docker/deprecated_images.json
+++ b/docker/deprecated_images.json
@@ -461,7 +461,7 @@
     },
     {
         "image_name": "demisto/nltk",
-        "reason": "The image is used exclusively by the deprecated content script WordTokenizer.",
+        "reason": "Image no longer in use by content",
         "created_time_utc": "2024-07-23T11:34:04.271203Z"
     }
 ]

--- a/docker/nltk/build.conf
+++ b/docker/nltk/build.conf
@@ -1,1 +1,3 @@
 version=2.0.0
+deprecated=true
+deprecated_reason=The image is used exclusively by the deprecated content script WordTokenizer.


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-11242)

## Description
Deprecate the `nltk` docker image as it is used exclusively by the deprecated script `WordTokenizer`.


