### PR TITLE
[Naitve]  `openssl-devel --nobest`

### DIFF
--- a/docker/py3-native/Dockerfile
+++ b/docker/py3-native/Dockerfile
@@ -75,7 +75,7 @@ RUN dnf update --nodocs -y  \
 # line 6 - since in ubi its 7za --> need to make it to run as 7z like our script
 # lines 8-10 is the configuration for sklearn
 # lines 12-14 - ssl fixes
-RUN dnf install -y --nodocs --enablerepo=$ROCKY_RELEASE python3-devel gcc gcc-c++ make wget git poppler poppler-utils \
+RUN dnf install -y --nodocs --enablerepo=$ROCKY_RELEASE --nobest python3-devel gcc gcc-c++ make wget git poppler poppler-utils \
         rust cargo libxml2-devel libxslt-devel krb5-devel \
         libffi-devel openssl-devel libffi libSM mesa-libGL \
         openssh ca-certificates openssl less rsync libpng-devel freetype-devel gcc-gfortran openblas unzip libstdc++ \


### PR DESCRIPTION
Because of this issue we added the `--nobest` flag
```
Problem: cannot install the best candidate for the job
nothing provides openssl-libs(x86-64) = 1:3.0.7-27.el9.0.2 needed by openssl-devel-1:3.0.7-27.el9.0.2.x86_64 from rocky-release
```