### PR TITLE
CIAC-11745 update version werkzeug

### DIFF
--- a/docker/xsoar-tools/Pipfile.lock
+++ b/docker/xsoar-tools/Pipfile.lock
@@ -2158,7 +2158,7 @@
                 "sha256:bba1f19f8ec89d4d607a3bd62f1904bd2e609472d93cd85e9d4e178f472c3748"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.3.8"
+            "version": "==3.0.3"
         },
         "wrapt": {
             "hashes": [


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/In Progress/In Hold (Reason for hold)

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: 
https://jira-dc.paloaltonetworks.com/browse/CIAC-11745

## Description
Update version werkzeug from 2.3.8 to 3.0.3
