### PR TITLE
pipfile lock for anyrun-sdk docker image

### DIFF
--- a/docker/anyrun-sdk/Pipfile.lock
+++ b/docker/anyrun-sdk/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c88e46e3865535dd356ed0d7ca966dcfae2afba8775ea3e65bb084e2596890f0"
+            "sha256": "10406024321eb53980226052cbefcbc14919340dff165574912da3936edcb275"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.12"
         },
         "sources": [
             {
@@ -135,14 +135,6 @@
             "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==1.2.3"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Content Pull Request
Related PR: link to the PR at demisto/content

## Related Issues
Related: link to the issue

## Description
Locked pipfile as the automatic flow after merging contrib (https://github.com/demisto/dockerfiles/pull/36310) failed.
