### PR TITLE
Pin github actions

### DIFF
--- a/.github/workflows/create-update-dockerfiles-PR.yml
+++ b/.github/workflows/create-update-dockerfiles-PR.yml
@@ -15,7 +15,7 @@ jobs:
       branches: ${{ steps.generate-matrix.outputs.branches }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Generate Matrix
         id: generate-matrix
         env:
@@ -45,10 +45,10 @@ jobs:
       matrix:
         branches: ${{ fromJSON(needs.get_branches.outputs.branches) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: pull-request
       id: open-pr
-      uses: repo-sync/pull-request@v2
+      uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
       with:
         GITHUB_TOKEN: ${{secrets.CONTENT_BOT_TOKEN}}
         source_branch: "${{ matrix.branches }}"

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.6
+        uses: dependabot/fetch-metadata@4de7a6c08ce727a42e0adbbdc345f761a01240ce # v1.3.6
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve and auto-merge for Dependabot PRs

--- a/.github/workflows/native-docker-labeled.yml
+++ b/.github/workflows/native-docker-labeled.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]' && contains(github.event.pull_request.title, 'autoupdate') == false && github.repository == 'demisto/dockerFiles'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: "3.11"
       - name: Run native_docker_labeled Script

--- a/.github/workflows/update-external-base-images.yml
+++ b/.github/workflows/update-external-base-images.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: '3.12'
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
       - name: run
         run: |
             git config --global user.email ""

--- a/.github/workflows/update-internal-base-images.yml
+++ b/.github/workflows/update-internal-base-images.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: '3.12'
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
       - name: run
         run: |
             git config --global user.email ""

--- a/.github/workflows/verify-script-update-notifier.yml
+++ b/.github/workflows/verify-script-update-notifier.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]' && contains(github.event.pull_request.title, 'autoupdate') == false && github.repository == 'demisto/dockerFiles'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: "3.11"
       - name: Run update_verify_script Script.


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions