### PR TITLE
Add docker login before docker build

### DIFF
--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -230,7 +230,11 @@ function docker_build {
         reason=$(prop 'deprecated_reason')
         echo "ENV DEPRECATED_REASON=\"$reason\"" >> "$tmp_dir/Dockerfile"
     fi
-    
+
+    echo "### DOCKER LOGIN START ###"
+    docker_login
+    echo "### DOCKER LOGIN DONE ###"
+
     docker buildx build -f "$tmp_dir/Dockerfile" . -t ${image_full_name} \
         --label "org.opencontainers.image.authors=Demisto <containers@demisto.com>" \
         --label "org.opencontainers.image.version=${VERSION}" \


### PR DESCRIPTION
## Description
In order to not get `toomanyrequests: You have reached your unauthenticated pull rate limit.`
I added the docker_login function before building the docker