### PR TITLE
feat: add gss-ntlmssp package and optimize Docker layers for Ubuntu i…

### DIFF
--- a/docker/powershell/verify.ps1
+++ b/docker/powershell/verify.ps1
@@ -7,20 +7,4 @@ if ($(Get-TimeZone).Id -ne 'Etc/UTC' -and $(Get-TimeZone).Id -ne 'UCT' -and $(Ge
     throw "TimeZone.Id not equal to Etc/UTC or UCT or Zulu. Value: " + $(Get-TimeZone).Id
 }
 
-function Test-SystemPackage {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [string]$Name
-    )
-
-    /usr/bin/dpkg-query -s $Name > $null 2>&1
-    return $LASTEXITCODE -eq 0
-}
-
-Write-Host("Verifying gss-ntlmssp installation...")
-if (-not (Test-SystemPackage -Name 'gss-ntlmssp')) {
-    throw "Verification failed: gss-ntlmssp is not installed."
-}
-
 Write-Output("All good. pwsh is setup fine!")


### PR DESCRIPTION
## Related Issues
Related: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-55409)

## Description
As part of the docker image Ubuntu was upgraded from 20.04 to 22.04. 
The update caused the integration to throw the following error:
`Connecting to remote server <server> failed with the following error message : acquiring creds with username only failed No credentials were supplied, or the credentials were unavailable or inaccessible SPNEGO cannot find mechanisms to negotiate For more information, see the about_Remote_Troubleshooting Help topic. (85)`

SPNEGO (Simple and Protected GSSAPI Negotiation Mechanism)
SPNEGO relies on Kerberos and NTLM as a fallback.

The gss-ntlmssp package version 1.2.1  provides the SPNEGO that critical NTLM fallback. 
