### PR TITLE
deprecated python3-9-deb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -748,10 +748,6 @@ updates:
     schedule:
      interval: daily
   - package-ecosystem: pip
-    directory: /docker/python3-9-deb
-    schedule:
-     interval: daily
-  - package-ecosystem: pip
     directory: /docker/cyberchef
     schedule:
      interval: daily  

--- a/docker/deprecated_images.json
+++ b/docker/deprecated_images.json
@@ -320,6 +320,11 @@
         "reason": "Python 2 is EOL. Use the python3-deb image instead."
     },
     {
+        "created_time_utc": "2025-09-11 23:26:37.667951",
+        "image_name": "demisto/python3-9-deb",
+        "reason": "No available replacement."
+    },
+    {
         "created_time_utc": "2022-05-31T17:55:37.149145Z",
         "image_name": "demisto/python3-arrow",
         "reason": "Use the demisto/py3-tools docker image instead."

--- a/docker/python3-9-deb/build.conf
+++ b/docker/python3-9-deb/build.conf
@@ -1,1 +1,2 @@
-# Name value properties to use while doing a build
+deprecated=true
+deprecated_reason=No available replacement.


### PR DESCRIPTION
## Description
The dokcer "python3-9-deb" has been deprecated as it is no longer being used by anyone. This decision has been approved by its creator, @jlevypaloalto.