### PR TITLE
del confluent-kafka from the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -716,10 +716,6 @@ updates:
     schedule:
      interval: daily
   - package-ecosystem: pip
-    directory: /docker/confluent-kafka
-    schedule:
-     interval: daily
-  - package-ecosystem: pip
     directory: /docker/pytmv1
     ignore:
       - dependency-name: "pytmv1"


### PR DESCRIPTION
## Description
del confluent-kafka from the dependabot config, because it is already a deprecated image
