### PR TITLE
build(dockerfiles) Update & Lock aquatone

### DIFF
--- a/docker/aquatone/Dockerfile
+++ b/docker/aquatone/Dockerfile
@@ -1,4 +1,4 @@
-# Last modified: 2025-09-12T01:21:08.331803
+# Last modified: 2025-09-12T03:11:14.185937+00:00
 FROM demisto/python3-deb:3.12.11.4801753
 
 RUN apt-get update \


### PR DESCRIPTION

            Automated update for demisto/aquatone:
            - Updated Last modified timestamp to 2025-09-12T03:11:14.185937+00:00
            - Updated dependencies (poetry/pipenv lock)
            - Addresses high/critical CVE vulnerabilities
            
            Please review and merge if appropriate.
            