### PR TITLE
build(dockerfiles) Update & Lock argus-toolbelt

### DIFF
--- a/docker/argus-toolbelt/Dockerfile
+++ b/docker/argus-toolbelt/Dockerfile
@@ -1,4 +1,4 @@
-# Last modified: 2025-09-12T01:37:42.521094+00:00
+# Last modified: 2025-09-12T03:11:14.185937+00:00
 
 FROM demisto/python3:3.12.11.4819260
 


### PR DESCRIPTION

            Automated update for demisto/argus-toolbelt:
            - Updated Last modified timestamp to 2025-09-12T03:11:14.185937+00:00
            - Updated dependencies (poetry/pipenv lock)
            - Addresses high/critical CVE vulnerabilities
            
            Please review and merge if appropriate.
            