### PR TITLE
build(dockerfiles) Update & Lock bigquery

### DIFF
--- a/docker/bigquery/Dockerfile
+++ b/docker/bigquery/Dockerfile
@@ -1,5 +1,5 @@
 
-# Last modified: 2025-09-12T01:54:14.196578+00:00
+# Last modified: 2025-09-12T03:11:14.185937+00:00
 
 FROM demisto/python3-deb:3.12.11.4801753
 


### PR DESCRIPTION

            Automated update for demisto/bigquery:
            - Updated Last modified timestamp to 2025-09-12T03:11:14.185937+00:00
            - Updated dependencies (poetry/pipenv lock)
            - Addresses high/critical CVE vulnerabilities
            
            Please review and merge if appropriate.
            