### PR TITLE
build(dockerfiles) Update & Lock google-vision-api

### DIFF
--- a/docker/google-vision-api/Dockerfile
+++ b/docker/google-vision-api/Dockerfile
@@ -1,3 +1,4 @@
+# Last modified: 2025-09-12T03:11:14.185937+00:00
 
 FROM demisto/python3-deb:3.12.11.4801753
 

--- a/docker/google-vision-api/Pipfile.lock
+++ b/docker/google-vision-api/Pipfile.lock
@@ -192,12 +192,12 @@
         },
         "google-auth-oauthlib": {
             "hashes": [
-                "sha256:2d58a27262d55aa1b87678c3ba7142a080098cbc2024f903c62355deb235d91f",
-                "sha256:afd0cad092a2eaa53cd8e8298557d6de1034c6cb4a740500b5357b648af97263"
+                "sha256:11046fb8d3348b296302dd939ace8af0a724042e8029c1b872d87fabc9f41684",
+                "sha256:fd619506f4b3908b5df17b65f39ca8d66ea56986e5472eb5978fd8f3786f00a2"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==1.2.1"
+            "version": "==1.2.2"
         },
         "google-cloud-aiplatform": {
             "hashes": [
@@ -242,12 +242,12 @@
         },
         "google-cloud-vision": {
             "hashes": [
-                "sha256:531e101b2ccad922433ad46c46a47529e64a0973346f30f91a012de163a52311",
-                "sha256:91959ea12b0d6a8442e30c0a5062cd305f349a4840f9184b5061b3153bbd8476"
+                "sha256:42a17fbc2219b0a88e325e2c1df6664a8dafcbae66363fb37ebcb511b018fc87",
+                "sha256:649380faab8933440b632bf88072c0c382a08d49ab02bc0b4fba821882ae1765"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.10.1"
+            "version": "==3.10.2"
         },
         "google-crc32c": {
             "hashes": [
@@ -523,11 +523,11 @@
         },
         "oauthlib": {
             "hashes": [
-                "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca",
-                "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"
+                "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9",
+                "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.2.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.3.1"
         },
         "packaging": {
             "hashes": [
@@ -547,19 +547,19 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:15eba1b86f193a407607112ceb9ea0ba9569aed24f93333fe9a497cf2fda37d3",
-                "sha256:501fe6372fd1c8ea2a30b4d9be8f87955a64d6be9c88a973996cef5ef6f0abf1",
-                "sha256:75a2aab2bd1aeb1f5dc7c5f33bcb11d82ea8c055c9becbb41c26a8c43fd7092c",
-                "sha256:7db8ed09024f115ac877a1427557b838705359f047b2ff2f2b2364892d19dacb",
-                "sha256:84f9e3c1ff6fb0308dbacb0950d8aa90694b0d0ee68e75719cb044b7078fe741",
-                "sha256:a81439049127067fc49ec1d36e25c6ee1d1a2b7be930675f919258d03c04e7d2",
-                "sha256:a8bdbb2f009cfc22a36d031f22a625a38b615b5e19e558a7b756b3279723e68e",
-                "sha256:ba377e5b67b908c8f3072a57b63e2c6a4cbd18aea4ed98d2584350dbf46f2783",
-                "sha256:d52691e5bee6c860fff9a1c86ad26a13afbeb4b168cd4445c922b7e2cf85aaf0"
+                "sha256:2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346",
+                "sha256:2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4",
+                "sha256:68ff170bac18c8178f130d1ccb94700cf72852298e016a2443bdb9502279e5f1",
+                "sha256:a8a32a84bc9f2aad712041b8b366190f71dde248926da517bde9e832e4412085",
+                "sha256:b00a7d8c25fa471f16bc8153d0e53d6c9e827f0953f3c09aaa4331c718cae5e1",
+                "sha256:b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710",
+                "sha256:d0975d0b2f3e6957111aa3935d08a0eb7e006b1505d825f862a1fffc8348e122",
+                "sha256:d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281",
+                "sha256:ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==6.32.0"
+            "version": "==6.32.1"
         },
         "pyasn1": {
             "hashes": [


### PR DESCRIPTION

            Automated update for demisto/google-vision-api:
            - Updated Last modified timestamp to 2025-09-12T03:11:14.185937+00:00
            - Updated dependencies (poetry/pipenv lock)
            - Addresses high/critical CVE vulnerabilities
            
            Please review and merge if appropriate.
            