### PR TITLE
build(dockerfiles) Update & Lock unzip

### DIFF
--- a/docker/unzip/Dockerfile
+++ b/docker/unzip/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends p7zip-full \
 RUN echo "deb http://deb.debian.org/debian bookworm contrib non-free" >> /etc/apt/sources.list.d/contrib-nonfree.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends unrar \
+# Last modified: 2025-09-12T03:11:14.185937+00:00
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION

            Automated update for demisto/unzip:
            - Updated Last modified timestamp to 2025-09-12T03:11:14.185937+00:00
            - Updated dependencies (poetry/pipenv lock)
            - Addresses high/critical CVE vulnerabilities
            
            Please review and merge if appropriate.
            