### PR TITLE
del zeep from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,10 +78,6 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: pip
-    directory: /docker/zeep
-    schedule:
-      interval: daily
-  - package-ecosystem: pip
     directory: /docker/dockerbuild
     schedule:
       interval: daily


### PR DESCRIPTION
## Description
This image is deprecated 
