### PR TITLE
deprecated jq

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -470,10 +470,6 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: pip
-    directory: /docker/jq
-    schedule:
-      interval: daily
-  - package-ecosystem: pip
     directory: /docker/lxml
     schedule:
       interval: daily

--- a/docker/deprecated_images.json
+++ b/docker/deprecated_images.json
@@ -205,6 +205,11 @@
         "reason": "Use the demisto/vendors-sdk docker image instead."
     },
     {
+        "created_time_utc": "2025-09-18 09:38:18.869188",
+        "image_name": "demisto/jq",
+        "reason": "Due to the lack of updates for the pyjq library over the last three years and its incompatibility with newer Python versions."
+    },
+    {
         "created_time_utc": "2022-05-31T17:54:32.444316Z",
         "image_name": "demisto/langdetect",
         "reason": "Use the demisto/py3-tools docker image instead."

--- a/docker/jq/build.conf
+++ b/docker/jq/build.conf
@@ -1,1 +1,3 @@
 version=1.0.0
+deprecated=true
+deprecated_reason=Due to the lack of updates for the pyjq library over the last three years and its incompatibility with newer Python versions.


### PR DESCRIPTION
## Related Content Pull Request
Related PR: https://github.com/demisto/content/pull/41352

## Description

Due to the lack of updates for the pyjq library over the last three years and its incompatibility with newer Python versions, we have deprecated this transformer. You can now use the official JMESPath transformer instead.