### PR TITLE
build(dockerfiles) Update & Lock auth-utils

### DIFF
--- a/docker/auth-utils/Dockerfile
+++ b/docker/auth-utils/Dockerfile
@@ -1,6 +1,6 @@
-# Last modified: 2025-10-21T12:45:51.571760+00:00
+# Last modified: 2026-02-02T12:39:34.255601+00:00
 
-FROM demisto/crypto:1.0.0.5490413
+FROM demisto/crypto:1.0.0.6932158
 
 COPY requirements.txt .
 


### PR DESCRIPTION

            Automated update for demisto/auth-utils:
            - Updated Last modified timestamp to 2026-02-02T12:39:34.255601+00:00
            - Updated dependencies (poetry/pipenv lock)
            
            Please review and merge if appropriate.
            