### PR TITLE
build(dockerfiles) Update & Lock netutils

### DIFF
--- a/docker/netutils/Dockerfile
+++ b/docker/netutils/Dockerfile
@@ -1,6 +1,6 @@
-# Last modified: 2025-12-05T04:40:36.247324+00:00
+# Last modified: 2026-02-11T15:18:34.933506+00:00
 
-FROM demisto/python3:3.12.12.6151721
+FROM demisto/python3:3.12.12.7090913
 
 RUN mkdir /opt/scripts
 


### PR DESCRIPTION

            Automated update for demisto/netutils:
            - Updated Last modified timestamp to 2026-02-11T15:18:34.933506+00:00
            - Updated dependencies (poetry/pipenv lock)
            
            Please review and merge if appropriate.
            