### PR TITLE
build(dockerfiles) Update & Lock stringsifter

### DIFF
--- a/docker/stringsifter/Dockerfile
+++ b/docker/stringsifter/Dockerfile
@@ -1,9 +1,9 @@
-# Last modified: 2025-09-12T03:11:14.185937+00:00
-FROM demisto/python3-deb:3.11.10.117398
+# Last modified: 2026-02-11T15:18:34.933506+00:00
+FROM demisto/python3-deb:3.12.12.7090913
 # because of this issue we still using 3.11 https://github.com/mandiant/stringsifter/issues/41
 
 COPY requirements.txt .
-# The base image demisto/python3-deb:3.11.10.117398 has bullseye-backports repository configured in its apt sources,
+# The base image demisto/python3-deb:3.12.12.7090913 has bullseye-backports repository configured in its apt sources,
 # but this repository is returning a 404 Not Found error because it's no longer available.
 RUN sed -i '/bullseye-backports/d' /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null || true \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python3-dev  \


### PR DESCRIPTION

            Automated update for demisto/stringsifter:
            - Updated Last modified timestamp to 2026-02-11T15:18:34.933506+00:00
            - Updated dependencies (poetry/pipenv lock)
            
            Please review and merge if appropriate.
            