### PR TITLE
build(dockerfiles) Update & Lock aquatone

### DIFF
--- a/docker/aquatone/Dockerfile
+++ b/docker/aquatone/Dockerfile
@@ -1,5 +1,5 @@
-# Last modified: 2025-12-31T04:44:21.131431+00:00
-FROM demisto/python3-deb:3.12.12.6493338
+# Last modified: 2026-03-05T11:31:05.509594+00:00
+FROM demisto/python3-deb:3.12.13.7425833
 
 RUN apt-get update \
 && apt-get install -y --no-install-recommends \


### PR DESCRIPTION

            Automated update for demisto/aquatone:
            - Updated Last modified timestamp to 2026-03-05T11:31:05.509594+00:00
            - Updated dependencies (poetry/pipenv lock)
            
            Please review and merge if appropriate.
            