### PR TITLE
fix(sklearn): fail build when NLTK data download fails

### DIFF
--- a/docker/sklearn/Dockerfile
+++ b/docker/sklearn/Dockerfile
@@ -17,7 +17,20 @@ RUN apk --update add --no-cache --virtual .build-dependencies python3-dev build-
   && apk del .build-dependencies
 
 RUN mkdir /ml
-RUN python -c "import nltk; nltk.download('wordnet', download_dir='/ml/nltk_data'); nltk.download('stopwords', download_dir='/ml/nltk_data'); nltk.download('punkt_tab', download_dir='/ml/nltk_data')"
+# nltk.download() returns False on failure instead of raising, so its result must be
+# checked: a transient CDN error must fail the build rather than ship empty corpora.
+RUN NLTK_MAX_ATTEMPTS=3; NLTK_RETRY_DELAY_SECONDS=5; \
+    for resource in wordnet stopwords punkt_tab; do \
+        attempt=1; \
+        until python -c "import sys, nltk; sys.exit(0 if nltk.download('$resource', download_dir='/ml/nltk_data') else 1)"; do \
+            if [ "$attempt" -ge "$NLTK_MAX_ATTEMPTS" ]; then \
+                echo "ERROR: failed to download NLTK resource '$resource' after $NLTK_MAX_ATTEMPTS attempts" >&2; \
+                exit 1; \
+            fi; \
+            attempt=$((attempt + 1)); \
+            sleep "$NLTK_RETRY_DELAY_SECONDS"; \
+        done; \
+    done
 
 ENV NLTK_DATA='/ml/nltk_data'
 RUN chown -R demisto:demisto /ml && chmod -R 775 /ml

--- a/docker/sklearn/verify.py
+++ b/docker/sklearn/verify.py
@@ -5,8 +5,20 @@ import nltk
 import dill
 import networkx
 from bs4 import BeautifulSoup
+from nltk.corpus import stopwords, wordnet
 
 import os
 assert int(os.environ['OPENBLAS_NUM_THREADS']) == 1
 
-print('All packages were imported successfully')
+# A failed nltk.download() at build time used to leave /ml/nltk_data empty and still
+# ship (XSUP-75716). nltk.data.find() only checks that a path exists, so a partial
+# extraction that creates empty directories would pass it. Load the corpora for real
+# instead, from the local NLTK_DATA only, so both cases fail the build.
+assert stopwords.words('english')
+assert wordnet.synsets('dog')
+
+# Exercise the code path that actually broke for users of FindEmailCampaign.
+assert nltk.tokenize.sent_tokenize('Hello there. General Kenobi.') == [
+    'Hello there.', 'General Kenobi.']
+
+print('All packages were imported successfully and NLTK data is available')


### PR DESCRIPTION
## Related Content Pull Request
<!-- Related PR: link to the PR at demisto/content -->

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->
fixes: XSUP-75716
## Description

To reproduce the bug
```sh
docker run --rm --platform linux/amd64 demisto/sklearn:1.0.0.10866354 \   
  python -c "from nltk.tokenize import sent_tokenize; print(sent_tokenize('Hello there. General Kenobi.'))"
```

The demisto/sklearn:1.0.0.10866354 image shipped with an empty /ml/nltk_data because nltk.download() returns False on failure rather than raising, so a transient CDN failure during the build committed a broken layer and still exited 0. verify.py only imported nltk and never touched the corpora, so the empty data dir passed verification.

Retry each download with backoff and raise on exhaustion, and assert the three resources exist in verify.py.