### PR TITLE
Fix MD4 unsupported hash type in py-ews for NTLM auth

### DIFF
--- a/docker/py-ews/Dockerfile
+++ b/docker/py-ews/Dockerfile
@@ -13,6 +13,18 @@ RUN apt-get update && apt-get -y --no-install-recommends upgrade \
 
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=0/g' /etc/ssl/openssl.cnf
 
+# Handling the issue described here: https://github.com/ecederstrand/exchangelib/issues/608
+# NTLM requires MD4 (NT hash = MD4(UTF-16LE(password))). OpenSSL 3.x moved MD4 into the
+# legacy provider, and the Debian openssl.cnf ships the provider block commented out, so
+# hashlib.new('md4') raises "unsupported hash type md4" (XSUP-76118).
+# legacy.so is already present in the image - it only needs to be activated.
+RUN cp /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf.md4-bak \
+&& sed -i 's|^# providers = provider_sect|providers = provider_sect|' /etc/ssl/openssl.cnf \
+&& printf '\n[provider_sect]\ndefault = default_sect\nlegacy = legacy_sect\n\n[default_sect]\nactivate = 1\n\n[legacy_sect]\nactivate = 1\n' >> /etc/ssl/openssl.cnf \
+&& grep -q '^providers = provider_sect' /etc/ssl/openssl.cnf \
+&& grep -q '^\[legacy_sect\]' /etc/ssl/openssl.cnf \
+&& openssl list -providers | grep -q 'OpenSSL Legacy Provider'
+
 COPY Pipfile.lock .
 COPY Pipfile .
 

--- a/docker/py-ews/verify.py
+++ b/docker/py-ews/verify.py
@@ -30,6 +30,7 @@ from exchangelib.version import (EXCHANGE_2007, EXCHANGE_2010,
                                  EXCHANGE_2010_SP2, EXCHANGE_2013,
                                  EXCHANGE_2016, EXCHANGE_2019)
 from future import utils as future_utils
+from ntlm_auth.compute_hash import _ntowfv1
 from requests.exceptions import ConnectionError
 from _sqlite3 import *
 
@@ -66,3 +67,11 @@ res.raise_for_status()
 
 # verify dateaparser works. We had a case that it failed with timezone issues
 dateparser.parse("10 minutes")
+
+# Make sure MD4 is enabled - NTLM authentication (XSUP-76118) cannot work without it.
+print(hashlib.algorithms_available)
+assert 'md4' in hashlib.algorithms_available
+hashlib.new('md4', b"text")
+
+# Verify the exact frame that NTLM authentication goes through
+assert _ntowfv1('Password01').hex() == '7100a909c7ff05b266af3c42ec058c33'


### PR DESCRIPTION
## Motivation / Background
This PR fixes issue XSUP-76118 where NTLM authentication in EWS v2 fails with `ValueError: unsupported hash type md4`. 

The `py-ews` image relies on OpenSSL 3.x (Debian-based), which moved MD4 to the legacy provider. Since the legacy provider was commented out by default in `/etc/ssl/openssl.cnf`, the `ntlm-auth` library failed instantly when attempting to generate the NT hash for authentication.

## Changes
* **Dockerfile:** Added `sed` commands to uncomment and activate the `legacy_sect` and `default_sect` providers in `/etc/ssl/openssl.cnf`. Added strict `grep` checks to fail the build if the configuration changes in the future base image.
* **verify.py:** Added an assertion to check that `md4` is present in `hashlib.algorithms_available` and explicitly validated the hash output. This ensures CI will automatically block any future base-image updates that break MD4 availability.

## Related Content PR
* **Content PR:** https://github.com/demisto/content/pull/45759

fixes: [XSUP-76118](https://jira-dc.paloaltonetworks.com/browse/XSUP-76118)
